### PR TITLE
Dispenser image

### DIFF
--- a/app/admin/actions.test.ts
+++ b/app/admin/actions.test.ts
@@ -3,8 +3,10 @@ import {
   createBuilding,
   createDispenser,
   deleteDispenser,
+  removeDispenserImage,
   updateBuildingPin,
   updateDispenser,
+  uploadDispenserImage,
 } from "@/app/admin/actions";
 import { requireAdminUser } from "@/lib/admin/auth";
 import { createSupabaseServerActionClient } from "@/lib/supabase/auth-server";
@@ -31,10 +33,16 @@ type SupabaseMockOptions = {
   insertBuildingError?: { message: string } | null;
   updateDispenserError?: { message: string } | null;
   updateDispenserData?: Array<{ dispenser_id: string }> | null;
+  updateImageError?: { message: string } | null;
+  updateImageData?: Array<{ dispenser_id: string }> | null;
   deleteError?: { message: string } | null;
-  deleteData?: Array<{ dispenser_id: string }> | null;
+  deleteData?: Array<{ dispenser_id: string; image_path?: string | null }> | null;
   updateBuildingError?: { message: string } | null;
   updateBuildingData?: Array<{ id: string }> | null;
+  dispenserLookupError?: { message: string } | null;
+  dispenserLookupData?: { image_path: string | null } | null;
+  storageUploadError?: { message: string } | null;
+  storageRemoveError?: { message: string } | null;
 };
 
 function makeSupabaseMock(options: SupabaseMockOptions = {}) {
@@ -59,13 +67,39 @@ function makeSupabaseMock(options: SupabaseMockOptions = {}) {
     .fn()
     .mockReturnValue({ eq: updateDispenserEqFirst });
 
+  const updateImageSelect = vi.fn().mockResolvedValue({
+    data: options.updateImageData ?? [{ dispenser_id: "dsp-1" }],
+    error: options.updateImageError ?? null,
+  });
+  const updateImageEqSecond = vi.fn().mockReturnValue({ select: updateImageSelect });
+  const updateImageEqFirst = vi.fn().mockReturnValue({ eq: updateImageEqSecond });
+  const updateImageCall = vi.fn().mockReturnValue({ eq: updateImageEqFirst });
+
+  const updateDispenserTable = vi.fn((values: Record<string, unknown>) => {
+    if (Object.prototype.hasOwnProperty.call(values, "image_path")) {
+      return updateImageCall(values);
+    }
+
+    return updateDispenserCall(values);
+  });
+
   const deleteSelect = vi.fn().mockResolvedValue({
-    data: options.deleteData ?? [{ dispenser_id: "dsp-1" }],
+    data: options.deleteData ?? [{ dispenser_id: "dsp-1", image_path: null }],
     error: options.deleteError ?? null,
   });
   const deleteEqSecond = vi.fn().mockReturnValue({ select: deleteSelect });
   const deleteEqFirst = vi.fn().mockReturnValue({ eq: deleteEqSecond });
   const deleteCall = vi.fn().mockReturnValue({ eq: deleteEqFirst });
+
+  const dispenserLookupMaybeSingle = vi.fn().mockResolvedValue({
+    data: options.dispenserLookupData ?? { image_path: null },
+    error: options.dispenserLookupError ?? null,
+  });
+  const dispenserLookupEqSecond = vi
+    .fn()
+    .mockReturnValue({ maybeSingle: dispenserLookupMaybeSingle });
+  const dispenserLookupEqFirst = vi.fn().mockReturnValue({ eq: dispenserLookupEqSecond });
+  const dispenserLookupSelect = vi.fn().mockReturnValue({ eq: dispenserLookupEqFirst });
 
   const updateBuildingSelect = vi.fn().mockResolvedValue({
     data: options.updateBuildingData ?? [{ id: "bld-1" }],
@@ -74,13 +108,25 @@ function makeSupabaseMock(options: SupabaseMockOptions = {}) {
   const updateBuildingEq = vi.fn().mockReturnValue({ select: updateBuildingSelect });
   const updateBuildingCall = vi.fn().mockReturnValue({ eq: updateBuildingEq });
 
+  const storageUpload = vi
+    .fn()
+    .mockResolvedValue({ error: options.storageUploadError ?? null });
+  const storageRemove = vi
+    .fn()
+    .mockResolvedValue({ error: options.storageRemoveError ?? null });
+  const storageFrom = vi.fn().mockReturnValue({
+    upload: storageUpload,
+    remove: storageRemove,
+  });
+
   return {
     from: vi.fn((table: string) => {
       if (table === "dispensers") {
         return {
           insert: insertDispenser,
-          update: updateDispenserCall,
+          update: updateDispenserTable,
           delete: deleteCall,
+          select: dispenserLookupSelect,
         };
       }
 
@@ -93,6 +139,9 @@ function makeSupabaseMock(options: SupabaseMockOptions = {}) {
 
       return {};
     }),
+    storage: {
+      from: storageFrom,
+    },
     auth: {
       signOut: vi.fn().mockResolvedValue({ error: null }),
     },
@@ -100,8 +149,12 @@ function makeSupabaseMock(options: SupabaseMockOptions = {}) {
       insertDispenser,
       insertBuilding,
       updateDispenserCall,
+      updateImageCall,
       deleteCall,
       updateBuildingCall,
+      dispenserLookupSelect,
+      storageUpload,
+      storageRemove,
     },
   };
 }
@@ -128,10 +181,9 @@ describe("admin server actions", () => {
       maintenanceStatus: "Operational",
     });
 
-    expect(result).toEqual({
-      ok: true,
-      message: "Dispenser added successfully.",
-    });
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe("Dispenser added successfully.");
+    expect(result.dispenserId).toBeTypeOf("string");
     expect(supabase.calls.insertDispenser).toHaveBeenCalledTimes(1);
     expect(revalidatePathMock).toHaveBeenCalledWith("/");
     expect(revalidatePathMock).toHaveBeenCalledWith("/admin");
@@ -197,6 +249,154 @@ describe("admin server actions", () => {
       message: "Dispenser removed successfully.",
     });
     expect(supabase.calls.deleteCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps dispenser deletion successful when image cleanup fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const supabase = makeSupabaseMock({
+      deleteData: [{ dispenser_id: "dsp-1", image_path: "bld-1/dsp-1/pic.jpg" }],
+      storageRemoveError: { message: "storage unavailable" },
+    });
+    createClientMock.mockResolvedValue(supabase as never);
+    requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
+
+    const result = await deleteDispenser({
+      buildingId: "bld-1",
+      dispenserId: "dsp-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Dispenser removed successfully.",
+    });
+    expect(supabase.calls.storageRemove).toHaveBeenCalledWith(["bld-1/dsp-1/pic.jpg"]);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("uploads dispenser image and updates image_path", async () => {
+    const supabase = makeSupabaseMock();
+    createClientMock.mockResolvedValue(supabase as never);
+    requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
+
+    const formData = new FormData();
+    formData.append("buildingId", "bld-1");
+    formData.append("dispenserId", "dsp-1");
+    formData.append(
+      "image",
+      new File([new Uint8Array([1, 2, 3])], "demo.png", { type: "image/png" })
+    );
+
+    const result = await uploadDispenserImage(formData);
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Dispenser image uploaded successfully.",
+    });
+    expect(supabase.calls.storageUpload).toHaveBeenCalledTimes(1);
+    expect(supabase.calls.updateImageCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces dispenser image and cleans up previous file", async () => {
+    const supabase = makeSupabaseMock({
+      dispenserLookupData: { image_path: "bld-1/dsp-1/old.jpg" },
+    });
+    createClientMock.mockResolvedValue(supabase as never);
+    requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
+
+    const formData = new FormData();
+    formData.append("buildingId", "bld-1");
+    formData.append("dispenserId", "dsp-1");
+    formData.append("image", new File(["next"], "next.webp", { type: "image/webp" }));
+
+    const result = await uploadDispenserImage(formData);
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Dispenser image uploaded successfully.",
+    });
+    expect(supabase.calls.storageRemove).toHaveBeenCalledWith(["bld-1/dsp-1/old.jpg"]);
+  });
+
+  it("removes dispenser image when admin user is authorized", async () => {
+    const supabase = makeSupabaseMock({
+      dispenserLookupData: { image_path: "bld-1/dsp-1/existing.jpg" },
+    });
+    createClientMock.mockResolvedValue(supabase as never);
+    requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
+
+    const result = await removeDispenserImage({
+      buildingId: "bld-1",
+      dispenserId: "dsp-1",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Dispenser image removed successfully.",
+    });
+    expect(supabase.calls.storageRemove).toHaveBeenCalledWith([
+      "bld-1/dsp-1/existing.jpg",
+    ]);
+    expect(supabase.calls.updateImageCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects invalid image type for uploads", async () => {
+    const formData = new FormData();
+    formData.append("buildingId", "bld-1");
+    formData.append("dispenserId", "dsp-1");
+    formData.append(
+      "image",
+      new File(["gif"], "bad.gif", {
+        type: "image/gif",
+      })
+    );
+
+    const result = await uploadDispenserImage(formData);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Unsupported image format. Use JPEG, PNG, or WEBP.",
+    });
+  });
+
+  it("rejects oversized image uploads", async () => {
+    const formData = new FormData();
+    formData.append("buildingId", "bld-1");
+    formData.append("dispenserId", "dsp-1");
+    formData.append(
+      "image",
+      new File([new Uint8Array(5 * 1024 * 1024 + 1)], "huge.png", {
+        type: "image/png",
+      })
+    );
+
+    const result = await uploadDispenserImage(formData);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Image size must be 5 MB or less.",
+    });
+  });
+
+  it("rejects upload when user is not an admin", async () => {
+    const supabase = makeSupabaseMock();
+    createClientMock.mockResolvedValue(supabase as never);
+    requireAdminMock.mockResolvedValue({
+      ok: false,
+      reason: "forbidden",
+      message: "forbidden",
+    });
+
+    const formData = new FormData();
+    formData.append("buildingId", "bld-1");
+    formData.append("dispenserId", "dsp-1");
+    formData.append("image", new File(["png"], "img.png", { type: "image/png" }));
+
+    const result = await uploadDispenserImage(formData);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "You must be an admin to perform this action.",
+    });
   });
 
   it("updates building pin when admin user is authorized", async () => {

--- a/app/admin/actions.test.ts
+++ b/app/admin/actions.test.ts
@@ -36,11 +36,15 @@ type SupabaseMockOptions = {
   updateImageError?: { message: string } | null;
   updateImageData?: Array<{ dispenser_id: string }> | null;
   deleteError?: { message: string } | null;
-  deleteData?: Array<{ dispenser_id: string; image_path?: string | null }> | null;
+  deleteData?: Array<{
+    dispenser_id: string;
+    image_paths?: string[] | null;
+    image_path?: string | null;
+  }> | null;
   updateBuildingError?: { message: string } | null;
   updateBuildingData?: Array<{ id: string }> | null;
   dispenserLookupError?: { message: string } | null;
-  dispenserLookupData?: { image_path: string | null } | null;
+  dispenserLookupData?: { image_paths?: string[] | null; image_path?: string | null } | null;
   storageUploadError?: { message: string } | null;
   storageRemoveError?: { message: string } | null;
 };
@@ -76,7 +80,10 @@ function makeSupabaseMock(options: SupabaseMockOptions = {}) {
   const updateImageCall = vi.fn().mockReturnValue({ eq: updateImageEqFirst });
 
   const updateDispenserTable = vi.fn((values: Record<string, unknown>) => {
-    if (Object.prototype.hasOwnProperty.call(values, "image_path")) {
+    if (
+      Object.prototype.hasOwnProperty.call(values, "image_path") ||
+      Object.prototype.hasOwnProperty.call(values, "image_paths")
+    ) {
       return updateImageCall(values);
     }
 
@@ -84,7 +91,9 @@ function makeSupabaseMock(options: SupabaseMockOptions = {}) {
   });
 
   const deleteSelect = vi.fn().mockResolvedValue({
-    data: options.deleteData ?? [{ dispenser_id: "dsp-1", image_path: null }],
+    data:
+      options.deleteData ??
+      [{ dispenser_id: "dsp-1", image_paths: [], image_path: null }],
     error: options.deleteError ?? null,
   });
   const deleteEqSecond = vi.fn().mockReturnValue({ select: deleteSelect });
@@ -92,7 +101,7 @@ function makeSupabaseMock(options: SupabaseMockOptions = {}) {
   const deleteCall = vi.fn().mockReturnValue({ eq: deleteEqFirst });
 
   const dispenserLookupMaybeSingle = vi.fn().mockResolvedValue({
-    data: options.dispenserLookupData ?? { image_path: null },
+    data: options.dispenserLookupData ?? { image_paths: [], image_path: null },
     error: options.dispenserLookupError ?? null,
   });
   const dispenserLookupEqSecond = vi
@@ -254,7 +263,12 @@ describe("admin server actions", () => {
   it("keeps dispenser deletion successful when image cleanup fails", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const supabase = makeSupabaseMock({
-      deleteData: [{ dispenser_id: "dsp-1", image_path: "bld-1/dsp-1/pic.jpg" }],
+      deleteData: [
+        {
+          dispenser_id: "dsp-1",
+          image_paths: ["bld-1/dsp-1/pic.jpg", "bld-1/dsp-1/pic-2.jpg"],
+        },
+      ],
       storageRemoveError: { message: "storage unavailable" },
     });
     createClientMock.mockResolvedValue(supabase as never);
@@ -269,11 +283,14 @@ describe("admin server actions", () => {
       ok: true,
       message: "Dispenser removed successfully.",
     });
-    expect(supabase.calls.storageRemove).toHaveBeenCalledWith(["bld-1/dsp-1/pic.jpg"]);
+    expect(supabase.calls.storageRemove).toHaveBeenCalledWith([
+      "bld-1/dsp-1/pic.jpg",
+      "bld-1/dsp-1/pic-2.jpg",
+    ]);
     expect(errorSpy).toHaveBeenCalled();
   });
 
-  it("uploads dispenser image and updates image_path", async () => {
+  it("uploads dispenser images and updates image_paths", async () => {
     const supabase = makeSupabaseMock();
     createClientMock.mockResolvedValue(supabase as never);
     requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
@@ -282,7 +299,7 @@ describe("admin server actions", () => {
     formData.append("buildingId", "bld-1");
     formData.append("dispenserId", "dsp-1");
     formData.append(
-      "image",
+      "images",
       new File([new Uint8Array([1, 2, 3])], "demo.png", { type: "image/png" })
     );
 
@@ -296,17 +313,15 @@ describe("admin server actions", () => {
     expect(supabase.calls.updateImageCall).toHaveBeenCalledTimes(1);
   });
 
-  it("replaces dispenser image and cleans up previous file", async () => {
-    const supabase = makeSupabaseMock({
-      dispenserLookupData: { image_path: "bld-1/dsp-1/old.jpg" },
-    });
+  it("accepts legacy single-image form payloads", async () => {
+    const supabase = makeSupabaseMock();
     createClientMock.mockResolvedValue(supabase as never);
     requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
 
     const formData = new FormData();
     formData.append("buildingId", "bld-1");
     formData.append("dispenserId", "dsp-1");
-    formData.append("image", new File(["next"], "next.webp", { type: "image/webp" }));
+    formData.append("image", new File(["legacy"], "legacy.jpg", { type: "image/jpeg" }));
 
     const result = await uploadDispenserImage(formData);
 
@@ -314,12 +329,44 @@ describe("admin server actions", () => {
       ok: true,
       message: "Dispenser image uploaded successfully.",
     });
-    expect(supabase.calls.storageRemove).toHaveBeenCalledWith(["bld-1/dsp-1/old.jpg"]);
+    expect(supabase.calls.storageUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends dispenser images without deleting existing files", async () => {
+    const supabase = makeSupabaseMock({
+      dispenserLookupData: {
+        image_paths: ["bld-1/dsp-1/old.jpg"],
+        image_path: "bld-1/dsp-1/old.jpg",
+      },
+    });
+    createClientMock.mockResolvedValue(supabase as never);
+    requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
+
+    const formData = new FormData();
+    formData.append("buildingId", "bld-1");
+    formData.append("dispenserId", "dsp-1");
+    formData.append("images", new File(["next"], "next.webp", { type: "image/webp" }));
+
+    const result = await uploadDispenserImage(formData);
+
+    expect(result).toEqual({
+      ok: true,
+      message: "Dispenser image uploaded successfully.",
+    });
+    expect(supabase.calls.storageRemove).not.toHaveBeenCalled();
+    expect(supabase.calls.updateImageCall.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        image_paths: expect.arrayContaining(["bld-1/dsp-1/old.jpg"]),
+      })
+    );
   });
 
   it("removes dispenser image when admin user is authorized", async () => {
     const supabase = makeSupabaseMock({
-      dispenserLookupData: { image_path: "bld-1/dsp-1/existing.jpg" },
+      dispenserLookupData: {
+        image_paths: ["bld-1/dsp-1/existing.jpg", "bld-1/dsp-1/existing-2.jpg"],
+        image_path: "bld-1/dsp-1/existing.jpg",
+      },
     });
     createClientMock.mockResolvedValue(supabase as never);
     requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
@@ -335,8 +382,15 @@ describe("admin server actions", () => {
     });
     expect(supabase.calls.storageRemove).toHaveBeenCalledWith([
       "bld-1/dsp-1/existing.jpg",
+      "bld-1/dsp-1/existing-2.jpg",
     ]);
     expect(supabase.calls.updateImageCall).toHaveBeenCalledTimes(1);
+    expect(supabase.calls.updateImageCall.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        image_paths: [],
+        image_path: null,
+      })
+    );
   });
 
   it("rejects invalid image type for uploads", async () => {
@@ -344,7 +398,7 @@ describe("admin server actions", () => {
     formData.append("buildingId", "bld-1");
     formData.append("dispenserId", "dsp-1");
     formData.append(
-      "image",
+      "images",
       new File(["gif"], "bad.gif", {
         type: "image/gif",
       })
@@ -363,7 +417,7 @@ describe("admin server actions", () => {
     formData.append("buildingId", "bld-1");
     formData.append("dispenserId", "dsp-1");
     formData.append(
-      "image",
+      "images",
       new File([new Uint8Array(5 * 1024 * 1024 + 1)], "huge.png", {
         type: "image/png",
       })
@@ -375,6 +429,38 @@ describe("admin server actions", () => {
       ok: false,
       message: "Image size must be 5 MB or less.",
     });
+  });
+
+  it("rejects uploads that exceed maximum image count", async () => {
+    const supabase = makeSupabaseMock({
+      dispenserLookupData: {
+        image_paths: [
+          "bld-1/dsp-1/1.jpg",
+          "bld-1/dsp-1/2.jpg",
+          "bld-1/dsp-1/3.jpg",
+          "bld-1/dsp-1/4.jpg",
+          "bld-1/dsp-1/5.jpg",
+          "bld-1/dsp-1/6.jpg",
+          "bld-1/dsp-1/7.jpg",
+          "bld-1/dsp-1/8.jpg",
+        ],
+      },
+    });
+    createClientMock.mockResolvedValue(supabase as never);
+    requireAdminMock.mockResolvedValue({ ok: true, email: "admin@example.com" });
+
+    const formData = new FormData();
+    formData.append("buildingId", "bld-1");
+    formData.append("dispenserId", "dsp-1");
+    formData.append("images", new File(["png"], "img.png", { type: "image/png" }));
+
+    const result = await uploadDispenserImage(formData);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Maximum 8 images are allowed per dispenser.",
+    });
+    expect(supabase.calls.storageUpload).not.toHaveBeenCalled();
   });
 
   it("rejects upload when user is not an admin", async () => {
@@ -389,7 +475,7 @@ describe("admin server actions", () => {
     const formData = new FormData();
     formData.append("buildingId", "bld-1");
     formData.append("dispenserId", "dsp-1");
-    formData.append("image", new File(["png"], "img.png", { type: "image/png" }));
+    formData.append("images", new File(["png"], "img.png", { type: "image/png" }));
 
     const result = await uploadDispenserImage(formData);
 

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -6,6 +6,7 @@ import type {
   CreateBuildingPayload,
   CreateBuildingResult,
   CreateDispenserPayload,
+  CreateDispenserResult,
   DeleteDispenserPayload,
   MutationResult,
   UpdateBuildingPinPayload,
@@ -20,12 +21,22 @@ import {
   validateDispenserId,
   validatePinPayload,
 } from "@/lib/admin/payload";
+import {
+  DISPENSER_IMAGE_BUCKET,
+  DISPENSER_IMAGE_MAX_BYTES,
+  buildDispenserImagePath,
+  getDispenserImageExtension,
+} from "@/lib/dispenser-images";
 import { toAdminSupabaseClient } from "@/lib/admin/supabase-adapter";
 import { createSupabaseServerActionClient } from "@/lib/supabase/auth-server";
 
 const AUTH_REQUIRED_MESSAGE = "You must be an admin to perform this action.";
 const DISPENSER_NOT_FOUND_MESSAGE = "Dispenser could not be found.";
 const BUILDING_NOT_FOUND_MESSAGE = "Building could not be found.";
+const IMAGE_REQUIRED_MESSAGE = "Please choose an image file.";
+const IMAGE_TYPE_MESSAGE =
+  "Unsupported image format. Use JPEG, PNG, or WEBP.";
+const IMAGE_SIZE_MESSAGE = "Image size must be 5 MB or less.";
 
 function success(message: string): MutationResult {
   return { ok: true, message };
@@ -33,6 +44,13 @@ function success(message: string): MutationResult {
 
 function failure(message: string): MutationResult {
   return { ok: false, message };
+}
+
+function successCreateDispenser(
+  message: string,
+  dispenserId: string
+): CreateDispenserResult {
+  return { ok: true, message, dispenserId };
 }
 
 async function ensureAdmin() {
@@ -46,9 +64,43 @@ function revalidateMapViews() {
   revalidatePath("/admin");
 }
 
+async function fetchDispenserImagePath(
+  supabase: Awaited<ReturnType<typeof createSupabaseServerActionClient>>,
+  buildingId: string,
+  dispenserId: string
+): Promise<{ ok: true; imagePath: string | null } | { ok: false; message: string }> {
+  const { data, error } = await supabase
+    .from("dispensers")
+    .select("image_path")
+    .eq("building_id", buildingId)
+    .eq("dispenser_id", dispenserId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[wmw-usm]", {
+      area: "admin",
+      operation: "fetch_dispenser_image_path",
+      message: error.message,
+      buildingId,
+      dispenserId,
+    });
+    return { ok: false, message: "Unable to load dispenser image details right now." };
+  }
+
+  if (!data || typeof data !== "object") {
+    return { ok: false, message: DISPENSER_NOT_FOUND_MESSAGE };
+  }
+
+  const row = data as { image_path?: unknown };
+  return {
+    ok: true,
+    imagePath: typeof row.image_path === "string" ? row.image_path : null,
+  };
+}
+
 export async function createDispenser(
   payload: CreateDispenserPayload
-): Promise<MutationResult> {
+): Promise<CreateDispenserResult> {
   const built = buildCreateDispenserRow(payload);
   if (!built.ok) {
     return failure(built.message);
@@ -71,7 +123,10 @@ export async function createDispenser(
   }
 
   revalidateMapViews();
-  return success("Dispenser added successfully.");
+  return successCreateDispenser(
+    "Dispenser added successfully.",
+    built.value.dispenser_id
+  );
 }
 
 export async function createBuilding(
@@ -168,7 +223,7 @@ export async function deleteDispenser(
     .delete()
     .eq("building_id", buildingId.value)
     .eq("dispenser_id", dispenserId.value)
-    .select("dispenser_id");
+    .select("dispenser_id,image_path");
 
   if (error) {
     console.error("[wmw-usm]", {
@@ -185,8 +240,231 @@ export async function deleteDispenser(
     return failure(DISPENSER_NOT_FOUND_MESSAGE);
   }
 
+  const imagePaths = data
+    .map((row) => {
+      if (!row || typeof row !== "object") {
+        return null;
+      }
+
+      const value = (row as { image_path?: unknown }).image_path;
+      return typeof value === "string" ? value : null;
+    })
+    .filter((value): value is string => Boolean(value));
+
+  if (imagePaths.length > 0) {
+    const { error: storageError } = await supabase.storage
+      .from(DISPENSER_IMAGE_BUCKET)
+      .remove(imagePaths);
+
+    if (storageError) {
+      console.error("[wmw-usm]", {
+        area: "admin",
+        operation: "delete_dispenser_image_cleanup",
+        message: storageError.message,
+        buildingId: buildingId.value,
+        dispenserId: dispenserId.value,
+      });
+    }
+  }
+
   revalidateMapViews();
   return success("Dispenser removed successfully.");
+}
+
+export async function uploadDispenserImage(
+  formData: FormData
+): Promise<MutationResult> {
+  const buildingId = validateBuildingId(String(formData.get("buildingId") ?? ""));
+  if (!buildingId.ok) {
+    return failure(buildingId.message);
+  }
+
+  const dispenserId = validateDispenserId(String(formData.get("dispenserId") ?? ""));
+  if (!dispenserId.ok) {
+    return failure(dispenserId.message);
+  }
+
+  const imageFile = formData.get("image");
+  if (!(imageFile instanceof File)) {
+    return failure(IMAGE_REQUIRED_MESSAGE);
+  }
+
+  if (imageFile.size > DISPENSER_IMAGE_MAX_BYTES) {
+    return failure(IMAGE_SIZE_MESSAGE);
+  }
+
+  const extension = getDispenserImageExtension(imageFile.type);
+  if (!extension) {
+    return failure(IMAGE_TYPE_MESSAGE);
+  }
+
+  const { supabase, guard } = await ensureAdmin();
+  if (!guard.ok) {
+    return failure(AUTH_REQUIRED_MESSAGE);
+  }
+
+  const currentImage = await fetchDispenserImagePath(
+    supabase,
+    buildingId.value,
+    dispenserId.value
+  );
+  if (!currentImage.ok) {
+    return currentImage;
+  }
+
+  const imagePath = buildDispenserImagePath(
+    buildingId.value,
+    dispenserId.value,
+    extension
+  );
+  const { error: uploadError } = await supabase.storage
+    .from(DISPENSER_IMAGE_BUCKET)
+    .upload(imagePath, imageFile, {
+      contentType: imageFile.type,
+      upsert: false,
+    });
+
+  if (uploadError) {
+    console.error("[wmw-usm]", {
+      area: "admin",
+      operation: "upload_dispenser_image_file",
+      message: uploadError.message,
+      buildingId: buildingId.value,
+      dispenserId: dispenserId.value,
+    });
+    return failure("Unable to upload dispenser image right now.");
+  }
+
+  const { data: updatedRows, error: updateError } = await supabase
+    .from("dispensers")
+    .update({
+      image_path: imagePath,
+    })
+    .eq("building_id", buildingId.value)
+    .eq("dispenser_id", dispenserId.value)
+    .select("dispenser_id");
+
+  if (updateError || !updatedRows?.length) {
+    const { error: cleanupError } = await supabase.storage
+      .from(DISPENSER_IMAGE_BUCKET)
+      .remove([imagePath]);
+
+    if (cleanupError) {
+      console.error("[wmw-usm]", {
+        area: "admin",
+        operation: "upload_dispenser_image_rollback",
+        message: cleanupError.message,
+        buildingId: buildingId.value,
+        dispenserId: dispenserId.value,
+      });
+    }
+
+    if (updateError) {
+      console.error("[wmw-usm]", {
+        area: "admin",
+        operation: "upload_dispenser_image_update_row",
+        message: updateError.message,
+        buildingId: buildingId.value,
+        dispenserId: dispenserId.value,
+      });
+      return failure("Unable to save dispenser image right now.");
+    }
+
+    return failure(DISPENSER_NOT_FOUND_MESSAGE);
+  }
+
+  if (currentImage.imagePath && currentImage.imagePath !== imagePath) {
+    const { error: previousImageCleanupError } = await supabase.storage
+      .from(DISPENSER_IMAGE_BUCKET)
+      .remove([currentImage.imagePath]);
+
+    if (previousImageCleanupError) {
+      console.error("[wmw-usm]", {
+        area: "admin",
+        operation: "upload_dispenser_image_replace_cleanup",
+        message: previousImageCleanupError.message,
+        buildingId: buildingId.value,
+        dispenserId: dispenserId.value,
+      });
+    }
+  }
+
+  revalidateMapViews();
+  return success("Dispenser image uploaded successfully.");
+}
+
+export async function removeDispenserImage(
+  payload: DeleteDispenserPayload
+): Promise<MutationResult> {
+  const buildingId = validateBuildingId(payload.buildingId);
+  if (!buildingId.ok) {
+    return failure(buildingId.message);
+  }
+
+  const dispenserId = validateDispenserId(payload.dispenserId);
+  if (!dispenserId.ok) {
+    return failure(dispenserId.message);
+  }
+
+  const { supabase, guard } = await ensureAdmin();
+  if (!guard.ok) {
+    return failure(AUTH_REQUIRED_MESSAGE);
+  }
+
+  const currentImage = await fetchDispenserImagePath(
+    supabase,
+    buildingId.value,
+    dispenserId.value
+  );
+  if (!currentImage.ok) {
+    return currentImage;
+  }
+
+  if (!currentImage.imagePath) {
+    return success("Dispenser image removed successfully.");
+  }
+
+  const { error: storageError } = await supabase.storage
+    .from(DISPENSER_IMAGE_BUCKET)
+    .remove([currentImage.imagePath]);
+
+  if (storageError) {
+    console.error("[wmw-usm]", {
+      area: "admin",
+      operation: "remove_dispenser_image_file",
+      message: storageError.message,
+      buildingId: buildingId.value,
+      dispenserId: dispenserId.value,
+    });
+    return failure("Unable to remove dispenser image right now.");
+  }
+
+  const { data, error } = await supabase
+    .from("dispensers")
+    .update({
+      image_path: null,
+    })
+    .eq("building_id", buildingId.value)
+    .eq("dispenser_id", dispenserId.value)
+    .select("dispenser_id");
+
+  if (error) {
+    console.error("[wmw-usm]", {
+      area: "admin",
+      operation: "remove_dispenser_image_update_row",
+      message: error.message,
+      buildingId: buildingId.value,
+      dispenserId: dispenserId.value,
+    });
+    return failure("Unable to remove dispenser image right now.");
+  }
+
+  if (!data?.length) {
+    return failure(DISPENSER_NOT_FOUND_MESSAGE);
+  }
+
+  revalidateMapViews();
+  return success("Dispenser image removed successfully.");
 }
 
 export async function updateBuildingPin(

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -24,6 +24,7 @@ import {
 import {
   DISPENSER_IMAGE_BUCKET,
   DISPENSER_IMAGE_MAX_BYTES,
+  DISPENSER_IMAGE_MAX_COUNT,
   buildDispenserImagePath,
   getDispenserImageExtension,
 } from "@/lib/dispenser-images";
@@ -37,6 +38,7 @@ const IMAGE_REQUIRED_MESSAGE = "Please choose an image file.";
 const IMAGE_TYPE_MESSAGE =
   "Unsupported image format. Use JPEG, PNG, or WEBP.";
 const IMAGE_SIZE_MESSAGE = "Image size must be 5 MB or less.";
+const IMAGE_COUNT_MESSAGE = `Maximum ${DISPENSER_IMAGE_MAX_COUNT} images are allowed per dispenser.`;
 
 function success(message: string): MutationResult {
   return { ok: true, message };
@@ -68,10 +70,10 @@ async function fetchDispenserImagePath(
   supabase: Awaited<ReturnType<typeof createSupabaseServerActionClient>>,
   buildingId: string,
   dispenserId: string
-): Promise<{ ok: true; imagePath: string | null } | { ok: false; message: string }> {
+): Promise<{ ok: true; imagePaths: string[] } | { ok: false; message: string }> {
   const { data, error } = await supabase
     .from("dispensers")
-    .select("image_path")
+    .select("image_paths,image_path")
     .eq("building_id", buildingId)
     .eq("dispenser_id", dispenserId)
     .maybeSingle();
@@ -91,10 +93,18 @@ async function fetchDispenserImagePath(
     return { ok: false, message: DISPENSER_NOT_FOUND_MESSAGE };
   }
 
-  const row = data as { image_path?: unknown };
+  const row = data as { image_paths?: unknown; image_path?: unknown };
+  const imagePaths = Array.isArray(row.image_paths)
+    ? row.image_paths.filter(
+        (value): value is string => typeof value === "string" && value.length > 0
+      )
+    : typeof row.image_path === "string" && row.image_path.length > 0
+      ? [row.image_path]
+      : [];
+
   return {
     ok: true,
-    imagePath: typeof row.image_path === "string" ? row.image_path : null,
+    imagePaths,
   };
 }
 
@@ -223,7 +233,7 @@ export async function deleteDispenser(
     .delete()
     .eq("building_id", buildingId.value)
     .eq("dispenser_id", dispenserId.value)
-    .select("dispenser_id,image_path");
+    .select("dispenser_id,image_paths,image_path");
 
   if (error) {
     console.error("[wmw-usm]", {
@@ -243,18 +253,30 @@ export async function deleteDispenser(
   const imagePaths = data
     .map((row) => {
       if (!row || typeof row !== "object") {
-        return null;
+        return [] as string[];
       }
 
-      const value = (row as { image_path?: unknown }).image_path;
-      return typeof value === "string" ? value : null;
-    })
-    .filter((value): value is string => Boolean(value));
+      const typedRow = row as {
+        image_paths?: unknown;
+        image_path?: unknown;
+      };
+      if (Array.isArray(typedRow.image_paths)) {
+        return typedRow.image_paths.filter(
+          (value): value is string => typeof value === "string" && value.length > 0
+        );
+      }
 
-  if (imagePaths.length > 0) {
+      return typeof typedRow.image_path === "string" && typedRow.image_path.length > 0
+        ? [typedRow.image_path]
+        : [];
+    })
+    .flat();
+  const uniqueImagePaths = [...new Set(imagePaths)];
+
+  if (uniqueImagePaths.length > 0) {
     const { error: storageError } = await supabase.storage
       .from(DISPENSER_IMAGE_BUCKET)
-      .remove(imagePaths);
+      .remove(uniqueImagePaths);
 
     if (storageError) {
       console.error("[wmw-usm]", {
@@ -284,18 +306,33 @@ export async function uploadDispenserImage(
     return failure(dispenserId.message);
   }
 
-  const imageFile = formData.get("image");
-  if (!(imageFile instanceof File)) {
+  const imageFiles = formData
+    .getAll("images")
+    .filter((value): value is File => value instanceof File);
+  const legacyImage = formData.get("image");
+  const filesToUpload =
+    imageFiles.length > 0
+      ? imageFiles
+      : legacyImage instanceof File
+        ? [legacyImage]
+        : [];
+
+  if (filesToUpload.length === 0) {
     return failure(IMAGE_REQUIRED_MESSAGE);
   }
 
-  if (imageFile.size > DISPENSER_IMAGE_MAX_BYTES) {
-    return failure(IMAGE_SIZE_MESSAGE);
-  }
+  const validatedImages: Array<{ file: File; extension: string }> = [];
+  for (const imageFile of filesToUpload) {
+    if (imageFile.size > DISPENSER_IMAGE_MAX_BYTES) {
+      return failure(IMAGE_SIZE_MESSAGE);
+    }
 
-  const extension = getDispenserImageExtension(imageFile.type);
-  if (!extension) {
-    return failure(IMAGE_TYPE_MESSAGE);
+    const extension = getDispenserImageExtension(imageFile.type);
+    if (!extension) {
+      return failure(IMAGE_TYPE_MESSAGE);
+    }
+
+    validatedImages.push({ file: imageFile, extension });
   }
 
   const { supabase, guard } = await ensureAdmin();
@@ -312,33 +349,59 @@ export async function uploadDispenserImage(
     return currentImage;
   }
 
-  const imagePath = buildDispenserImagePath(
-    buildingId.value,
-    dispenserId.value,
-    extension
-  );
-  const { error: uploadError } = await supabase.storage
-    .from(DISPENSER_IMAGE_BUCKET)
-    .upload(imagePath, imageFile, {
-      contentType: imageFile.type,
-      upsert: false,
-    });
-
-  if (uploadError) {
-    console.error("[wmw-usm]", {
-      area: "admin",
-      operation: "upload_dispenser_image_file",
-      message: uploadError.message,
-      buildingId: buildingId.value,
-      dispenserId: dispenserId.value,
-    });
-    return failure("Unable to upload dispenser image right now.");
+  if (currentImage.imagePaths.length + validatedImages.length > DISPENSER_IMAGE_MAX_COUNT) {
+    return failure(IMAGE_COUNT_MESSAGE);
   }
 
+  const uploadedPaths: string[] = [];
+  for (const image of validatedImages) {
+    const imagePath = buildDispenserImagePath(
+      buildingId.value,
+      dispenserId.value,
+      image.extension
+    );
+    const { error: uploadError } = await supabase.storage
+      .from(DISPENSER_IMAGE_BUCKET)
+      .upload(imagePath, image.file, {
+        contentType: image.file.type,
+        upsert: false,
+      });
+
+    if (uploadError) {
+      if (uploadedPaths.length > 0) {
+        const { error: cleanupError } = await supabase.storage
+          .from(DISPENSER_IMAGE_BUCKET)
+          .remove(uploadedPaths);
+
+        if (cleanupError) {
+          console.error("[wmw-usm]", {
+            area: "admin",
+            operation: "upload_dispenser_image_rollback",
+            message: cleanupError.message,
+            buildingId: buildingId.value,
+            dispenserId: dispenserId.value,
+          });
+        }
+      }
+      console.error("[wmw-usm]", {
+        area: "admin",
+        operation: "upload_dispenser_image_file",
+        message: uploadError.message,
+        buildingId: buildingId.value,
+        dispenserId: dispenserId.value,
+      });
+      return failure("Unable to upload dispenser image right now.");
+    }
+
+    uploadedPaths.push(imagePath);
+  }
+
+  const nextImagePaths = [...currentImage.imagePaths, ...uploadedPaths];
   const { data: updatedRows, error: updateError } = await supabase
     .from("dispensers")
     .update({
-      image_path: imagePath,
+      image_paths: nextImagePaths,
+      image_path: nextImagePaths[0] ?? null,
     })
     .eq("building_id", buildingId.value)
     .eq("dispenser_id", dispenserId.value)
@@ -347,7 +410,7 @@ export async function uploadDispenserImage(
   if (updateError || !updatedRows?.length) {
     const { error: cleanupError } = await supabase.storage
       .from(DISPENSER_IMAGE_BUCKET)
-      .remove([imagePath]);
+      .remove(uploadedPaths);
 
     if (cleanupError) {
       console.error("[wmw-usm]", {
@@ -373,24 +436,12 @@ export async function uploadDispenserImage(
     return failure(DISPENSER_NOT_FOUND_MESSAGE);
   }
 
-  if (currentImage.imagePath && currentImage.imagePath !== imagePath) {
-    const { error: previousImageCleanupError } = await supabase.storage
-      .from(DISPENSER_IMAGE_BUCKET)
-      .remove([currentImage.imagePath]);
-
-    if (previousImageCleanupError) {
-      console.error("[wmw-usm]", {
-        area: "admin",
-        operation: "upload_dispenser_image_replace_cleanup",
-        message: previousImageCleanupError.message,
-        buildingId: buildingId.value,
-        dispenserId: dispenserId.value,
-      });
-    }
-  }
-
   revalidateMapViews();
-  return success("Dispenser image uploaded successfully.");
+  return success(
+    validatedImages.length === 1
+      ? "Dispenser image uploaded successfully."
+      : "Dispenser images uploaded successfully."
+  );
 }
 
 export async function removeDispenserImage(
@@ -420,13 +471,13 @@ export async function removeDispenserImage(
     return currentImage;
   }
 
-  if (!currentImage.imagePath) {
+  if (currentImage.imagePaths.length === 0) {
     return success("Dispenser image removed successfully.");
   }
 
   const { error: storageError } = await supabase.storage
     .from(DISPENSER_IMAGE_BUCKET)
-    .remove([currentImage.imagePath]);
+    .remove(currentImage.imagePaths);
 
   if (storageError) {
     console.error("[wmw-usm]", {
@@ -442,6 +493,7 @@ export async function removeDispenserImage(
   const { data, error } = await supabase
     .from("dispensers")
     .update({
+      image_paths: [],
       image_path: null,
     })
     .eq("building_id", buildingId.value)

--- a/components/admin/AdminDashboard.test.tsx
+++ b/components/admin/AdminDashboard.test.tsx
@@ -90,8 +90,11 @@ const BUILDINGS = [
         brand: "Coway",
         coldWaterStatus: "Available" as const,
         maintenanceStatus: "Operational" as const,
-        imagePath: "bld-1/dsp-1/first.jpg",
-        imageUrl: "https://cdn.test/bld-1/dsp-1/first.jpg",
+        imagePaths: ["bld-1/dsp-1/first.jpg", "bld-1/dsp-1/second.jpg"],
+        imageUrls: [
+          "https://cdn.test/bld-1/dsp-1/first.jpg",
+          "https://cdn.test/bld-1/dsp-1/second.jpg",
+        ],
       },
       {
         id: "dsp-2",
@@ -100,6 +103,8 @@ const BUILDINGS = [
         brand: "Cuckoo",
         coldWaterStatus: "Unavailable" as const,
         maintenanceStatus: "Under Maintenance" as const,
+        imagePaths: [],
+        imageUrls: [],
       },
     ],
   },
@@ -116,6 +121,8 @@ const BUILDINGS = [
         brand: "Coway",
         coldWaterStatus: "Available" as const,
         maintenanceStatus: "Operational" as const,
+        imagePaths: [],
+        imageUrls: [],
       },
     ],
   },
@@ -142,6 +149,19 @@ describe("AdminDashboard inline editing and pin workflows", () => {
     expect(
       screen.getAllByLabelText("Save updates for 1st Floor Pantry")[0]
     ).toBeInTheDocument();
+  });
+
+  it("slides through dispenser images in list card", () => {
+    render(<AdminDashboard buildings={BUILDINGS} adminEmail="admin@example.com" />);
+
+    const image = screen.getByAltText("1st Floor Pantry dispenser");
+    expect(image).toHaveAttribute("src", "https://cdn.test/bld-1/dsp-1/first.jpg");
+
+    fireEvent.click(screen.getByLabelText("Next dispenser image"));
+    expect(screen.getByAltText("1st Floor Pantry dispenser")).toHaveAttribute(
+      "src",
+      "https://cdn.test/bld-1/dsp-1/second.jpg"
+    );
   });
 
   it("saves inline changes and calls updateDispenser with card payload", async () => {
@@ -173,14 +193,14 @@ describe("AdminDashboard inline editing and pin workflows", () => {
     });
   });
 
-  it("uploads image after creating dispenser when file is selected", async () => {
+  it("uploads images after creating dispenser when files are selected", async () => {
     const createDispenserMock = vi.mocked(adminActions.createDispenser);
     const uploadDispenserImageMock = vi.mocked(adminActions.uploadDispenserImage);
 
     render(<AdminDashboard buildings={BUILDINGS} adminEmail="admin@example.com" />);
 
     const file = new File(["image"], "new.png", { type: "image/png" });
-    fireEvent.change(screen.getByLabelText("Upload image for new dispenser"), {
+    fireEvent.change(screen.getByLabelText("Upload images for new dispenser"), {
       target: { files: [file] },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add Dispenser" }));
@@ -194,17 +214,17 @@ describe("AdminDashboard inline editing and pin workflows", () => {
     expect(formData).toBeInstanceOf(FormData);
     expect(formData?.get("buildingId")).toBe("bld-1");
     expect(formData?.get("dispenserId")).toBe("dsp-created");
-    expect(formData?.get("image")).toBe(file);
+    expect(formData?.getAll("images")).toEqual([file]);
   });
 
-  it("uploads replacement image from inline edit", async () => {
+  it("uploads new images from inline edit", async () => {
     const uploadDispenserImageMock = vi.mocked(adminActions.uploadDispenserImage);
 
     render(<AdminDashboard buildings={BUILDINGS} adminEmail="admin@example.com" />);
 
     fireEvent.click(screen.getAllByLabelText("Edit dispenser 1st Floor Pantry")[0]);
     const file = new File(["replacement"], "replace.webp", { type: "image/webp" });
-    fireEvent.change(screen.getByLabelText("Replace image for 1st Floor Pantry"), {
+    fireEvent.change(screen.getByLabelText("Add images for 1st Floor Pantry"), {
       target: { files: [file] },
     });
     fireEvent.click(screen.getByLabelText("Save updates for 1st Floor Pantry"));
@@ -216,7 +236,7 @@ describe("AdminDashboard inline editing and pin workflows", () => {
     const formData = uploadDispenserImageMock.mock.calls[0]?.[0];
     expect(formData?.get("buildingId")).toBe("bld-1");
     expect(formData?.get("dispenserId")).toBe("dsp-1");
-    expect(formData?.get("image")).toBe(file);
+    expect(formData?.getAll("images")).toEqual([file]);
   });
 
   it("removes existing image from inline edit", async () => {

--- a/components/admin/AdminDashboard.test.tsx
+++ b/components/admin/AdminDashboard.test.tsx
@@ -51,12 +51,21 @@ vi.mock("@/app/admin/actions", () => ({
   createDispenser: vi.fn().mockResolvedValue({
     ok: true,
     message: "created",
+    dispenserId: "dsp-created",
   }),
   deleteDispenser: vi.fn().mockResolvedValue({
     ok: true,
     message: "deleted",
   }),
+  removeDispenserImage: vi.fn().mockResolvedValue({
+    ok: true,
+    message: "image removed",
+  }),
   signOutAdmin: vi.fn(),
+  uploadDispenserImage: vi.fn().mockResolvedValue({
+    ok: true,
+    message: "image uploaded",
+  }),
   updateBuildingPin: vi.fn().mockResolvedValue({
     ok: true,
     message: "pin updated",
@@ -81,6 +90,8 @@ const BUILDINGS = [
         brand: "Coway",
         coldWaterStatus: "Available" as const,
         maintenanceStatus: "Operational" as const,
+        imagePath: "bld-1/dsp-1/first.jpg",
+        imageUrl: "https://cdn.test/bld-1/dsp-1/first.jpg",
       },
       {
         id: "dsp-2",
@@ -159,6 +170,71 @@ describe("AdminDashboard inline editing and pin workflows", () => {
       expect(
         screen.queryAllByLabelText("Edit location for 1st Floor Pantry")
       ).toHaveLength(0);
+    });
+  });
+
+  it("uploads image after creating dispenser when file is selected", async () => {
+    const createDispenserMock = vi.mocked(adminActions.createDispenser);
+    const uploadDispenserImageMock = vi.mocked(adminActions.uploadDispenserImage);
+
+    render(<AdminDashboard buildings={BUILDINGS} adminEmail="admin@example.com" />);
+
+    const file = new File(["image"], "new.png", { type: "image/png" });
+    fireEvent.change(screen.getByLabelText("Upload image for new dispenser"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add Dispenser" }));
+
+    await waitFor(() => {
+      expect(createDispenserMock).toHaveBeenCalledTimes(1);
+      expect(uploadDispenserImageMock).toHaveBeenCalledTimes(1);
+    });
+
+    const formData = uploadDispenserImageMock.mock.calls[0]?.[0];
+    expect(formData).toBeInstanceOf(FormData);
+    expect(formData?.get("buildingId")).toBe("bld-1");
+    expect(formData?.get("dispenserId")).toBe("dsp-created");
+    expect(formData?.get("image")).toBe(file);
+  });
+
+  it("uploads replacement image from inline edit", async () => {
+    const uploadDispenserImageMock = vi.mocked(adminActions.uploadDispenserImage);
+
+    render(<AdminDashboard buildings={BUILDINGS} adminEmail="admin@example.com" />);
+
+    fireEvent.click(screen.getAllByLabelText("Edit dispenser 1st Floor Pantry")[0]);
+    const file = new File(["replacement"], "replace.webp", { type: "image/webp" });
+    fireEvent.change(screen.getByLabelText("Replace image for 1st Floor Pantry"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByLabelText("Save updates for 1st Floor Pantry"));
+
+    await waitFor(() => {
+      expect(uploadDispenserImageMock).toHaveBeenCalledTimes(1);
+    });
+
+    const formData = uploadDispenserImageMock.mock.calls[0]?.[0];
+    expect(formData?.get("buildingId")).toBe("bld-1");
+    expect(formData?.get("dispenserId")).toBe("dsp-1");
+    expect(formData?.get("image")).toBe(file);
+  });
+
+  it("removes existing image from inline edit", async () => {
+    const removeDispenserImageMock = vi.mocked(adminActions.removeDispenserImage);
+
+    render(<AdminDashboard buildings={BUILDINGS} adminEmail="admin@example.com" />);
+
+    fireEvent.click(screen.getAllByLabelText("Edit dispenser 1st Floor Pantry")[0]);
+    fireEvent.click(
+      screen.getByLabelText("Toggle image removal for 1st Floor Pantry")
+    );
+    fireEvent.click(screen.getByLabelText("Save updates for 1st Floor Pantry"));
+
+    await waitFor(() => {
+      expect(removeDispenserImageMock).toHaveBeenCalledWith({
+        buildingId: "bld-1",
+        dispenserId: "dsp-1",
+      });
     });
   });
 

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type ChangeEvent,
   type FormEvent,
   type KeyboardEvent,
   useEffect,
@@ -15,10 +16,16 @@ import {
   createBuilding,
   createDispenser,
   deleteDispenser,
+  removeDispenserImage,
   signOutAdmin,
+  uploadDispenserImage,
   updateBuildingPin,
   updateDispenser,
 } from "@/app/admin/actions";
+import {
+  DISPENSER_IMAGE_ALLOWED_MIME_TYPES,
+  DISPENSER_IMAGE_MAX_BYTES,
+} from "@/lib/dispenser-images";
 import { MAINTENANCE_WRITE_OPTIONS } from "@/lib/admin/payload";
 import {
   COLD_WATER_STATUS_OPTIONS,
@@ -42,6 +49,9 @@ type EditDraft = {
   dispenserId: string;
   fields: DispenserMutationFields;
   original: DispenserMutationFields;
+  hasImage: boolean;
+  imageFile: File | null;
+  removeImage: boolean;
 };
 
 type PinWorkflow = "edit-existing" | "add-new";
@@ -52,6 +62,24 @@ const DISCARD_NEW_BUILDING_DRAFT_MESSAGE =
   "Discard unsaved new building draft? Your building name and pinned coordinates will be lost.";
 const DEFAULT_MUTATION_ERROR_MESSAGE =
   "Something went wrong while saving. Please try again.";
+const IMAGE_INPUT_ACCEPT = DISPENSER_IMAGE_ALLOWED_MIME_TYPES.join(",");
+const IMAGE_MAX_MB = Math.floor(DISPENSER_IMAGE_MAX_BYTES / (1024 * 1024));
+
+function validateImageFile(file: File): string | null {
+  if (
+    !DISPENSER_IMAGE_ALLOWED_MIME_TYPES.includes(
+      file.type as (typeof DISPENSER_IMAGE_ALLOWED_MIME_TYPES)[number]
+    )
+  ) {
+    return "Unsupported image format. Use JPEG, PNG, or WEBP.";
+  }
+
+  if (file.size > DISPENSER_IMAGE_MAX_BYTES) {
+    return `Image size must be ${IMAGE_MAX_MB} MB or less.`;
+  }
+
+  return null;
+}
 
 function initialFields(): DispenserMutationFields {
   return {
@@ -105,11 +133,13 @@ export default function AdminDashboard({
 }: AdminDashboardProps) {
   const router = useRouter();
   const editLocationInputRef = useRef<HTMLInputElement | null>(null);
+  const newImageInputRef = useRef<HTMLInputElement | null>(null);
 
   const [selectedBuildingId, setSelectedBuildingId] = useState<string | null>(
     buildings[0]?.id ?? null
   );
   const [newFields, setNewFields] = useState<DispenserMutationFields>(initialFields);
+  const [newImageFile, setNewImageFile] = useState<File | null>(null);
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [pinWorkflow, setPinWorkflow] = useState<PinWorkflow>("edit-existing");
   const [newBuildingName, setNewBuildingName] = useState("");
@@ -130,7 +160,11 @@ export default function AdminDashboard({
       return false;
     }
 
-    return !areDispenserFieldsEqual(editDraft.fields, editDraft.original);
+    return (
+      !areDispenserFieldsEqual(editDraft.fields, editDraft.original) ||
+      Boolean(editDraft.imageFile) ||
+      editDraft.removeImage
+    );
   }, [editDraft]);
 
   const isAddBuildingDraftDirty =
@@ -247,16 +281,65 @@ export default function AdminDashboard({
       setMessage("error", "Select a building before adding a dispenser.");
       return;
     }
+    const buildingId = selectedBuildingId;
 
     const payload: CreateDispenserPayload = {
-      buildingId: selectedBuildingId,
+      buildingId,
       ...newFields,
       maintenanceStatus: normalizeMaintenanceStatus(newFields.maintenanceStatus),
     };
 
-    runMutation(() => createDispenser(payload), () => {
-      setNewFields(initialFields());
-    });
+    const selectedImage = newImageFile;
+    if (selectedImage) {
+      const imageValidationMessage = validateImageFile(selectedImage);
+      if (imageValidationMessage) {
+        setMessage("error", imageValidationMessage);
+        return;
+      }
+    }
+
+    runMutation(
+      async () => {
+        const createResult = await createDispenser(payload);
+        if (!createResult.ok) {
+          return createResult;
+        }
+
+        if (!selectedImage) {
+          return createResult;
+        }
+
+        if (!createResult.dispenserId) {
+          return {
+            ok: false,
+            message:
+              "Dispenser was created, but image upload could not start. Please edit dispenser and upload image.",
+          };
+        }
+
+        const imageFormData = new FormData();
+        imageFormData.append("buildingId", buildingId);
+        imageFormData.append("dispenserId", createResult.dispenserId);
+        imageFormData.append("image", selectedImage);
+
+        const imageResult = await uploadDispenserImage(imageFormData);
+        if (!imageResult.ok) {
+          return imageResult;
+        }
+
+        return {
+          ok: true,
+          message: "Dispenser and image saved successfully.",
+        };
+      },
+      () => {
+        setNewFields(initialFields());
+        setNewImageFile(null);
+        if (newImageInputRef.current) {
+          newImageInputRef.current.value = "";
+        }
+      }
+    );
   };
 
   const handleStartEdit = (dispenser: Dispenser) => {
@@ -273,6 +356,9 @@ export default function AdminDashboard({
       dispenserId: dispenser.id,
       fields: nextFields,
       original: nextFields,
+      hasImage: Boolean(dispenser.imagePath),
+      imageFile: null,
+      removeImage: false,
     });
   };
 
@@ -286,19 +372,68 @@ export default function AdminDashboard({
       setMessage("error", "Pick a dispenser to update.");
       return;
     }
+    const buildingId = selectedBuildingId;
 
     const maintenanceStatus = normalizeMaintenanceStatus(
       editDraft.fields.maintenanceStatus
     );
+    const replacementImage = editDraft.imageFile;
+    const shouldRemoveImage = editDraft.removeImage;
+
+    if (replacementImage) {
+      const imageValidationMessage = validateImageFile(replacementImage);
+      if (imageValidationMessage) {
+        setMessage("error", imageValidationMessage);
+        return;
+      }
+    }
 
     runMutation(
-      () =>
-        updateDispenser({
-          buildingId: selectedBuildingId,
+      async () => {
+        const updateResult = await updateDispenser({
+          buildingId,
           dispenserId,
           ...editDraft.fields,
           maintenanceStatus,
-        }),
+        });
+
+        if (!updateResult.ok) {
+          return updateResult;
+        }
+
+        if (shouldRemoveImage) {
+          const removeResult = await removeDispenserImage({
+            buildingId,
+            dispenserId,
+          });
+
+          if (!removeResult.ok) {
+            return removeResult;
+          }
+        }
+
+        if (replacementImage) {
+          const imageFormData = new FormData();
+          imageFormData.append("buildingId", buildingId);
+          imageFormData.append("dispenserId", dispenserId);
+          imageFormData.append("image", replacementImage);
+
+          const uploadResult = await uploadDispenserImage(imageFormData);
+          if (!uploadResult.ok) {
+            return uploadResult;
+          }
+        }
+
+        if (replacementImage) {
+          return { ok: true, message: "Dispenser updated and image replaced." };
+        }
+
+        if (shouldRemoveImage) {
+          return { ok: true, message: "Dispenser updated and image removed." };
+        }
+
+        return updateResult;
+      },
       () => {
         setEditDraft(null);
       }
@@ -307,6 +442,51 @@ export default function AdminDashboard({
 
   const handleCancelEdit = () => {
     setEditDraft(null);
+  };
+
+  const handleNewImageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null;
+    setNewImageFile(file);
+  };
+
+  const handleEditImageChange = (
+    event: ChangeEvent<HTMLInputElement>,
+    dispenserId: string
+  ) => {
+    const file = event.target.files?.[0] ?? null;
+    setEditDraft((current) =>
+      current && current.dispenserId === dispenserId
+        ? {
+            ...current,
+            imageFile: file,
+            removeImage: file ? false : current.removeImage,
+          }
+        : current
+    );
+  };
+
+  const handleToggleEditImageRemoval = (dispenserId: string) => {
+    setEditDraft((current) => {
+      if (!current || current.dispenserId !== dispenserId) {
+        return current;
+      }
+
+      if (current.imageFile) {
+        return {
+          ...current,
+          imageFile: null,
+        };
+      }
+
+      if (!current.hasImage) {
+        return current;
+      }
+
+      return {
+        ...current,
+        removeImage: !current.removeImage,
+      };
+    });
   };
 
   const handleEditKeyDown = (event: KeyboardEvent<HTMLFormElement>) => {
@@ -694,6 +874,31 @@ export default function AdminDashboard({
                       </option>
                     ))}
                   </select>
+                  <div className="rounded-xl border border-dashed border-[#d4c6e8] bg-[#faf7ff] px-3 py-2.5">
+                    <label
+                      htmlFor="new-dispenser-image"
+                      className="mb-1 block text-xs font-semibold tracking-wide text-[#4a2d76] uppercase"
+                    >
+                      Dispenser Image (Optional)
+                    </label>
+                    <input
+                      id="new-dispenser-image"
+                      ref={newImageInputRef}
+                      type="file"
+                      accept={IMAGE_INPUT_ACCEPT}
+                      onChange={handleNewImageChange}
+                      aria-label="Upload image for new dispenser"
+                      className="w-full text-sm text-[#4a3a66] file:mr-3 file:rounded-lg file:border-0 file:bg-[#efe6fd] file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-[#4a2d76] hover:file:bg-[#e2d4fb]"
+                    />
+                    <p className="mt-1 text-xs text-[#6c5f84]">
+                      JPEG, PNG, or WEBP up to {IMAGE_MAX_MB} MB.
+                    </p>
+                    {newImageFile ? (
+                      <p className="mt-1 text-xs font-medium text-[#2f5b45]">
+                        Selected: {newImageFile.name}
+                      </p>
+                    ) : null}
+                  </div>
                   <button
                     type="submit"
                     disabled={!selectedBuilding || isPending}
@@ -723,6 +928,18 @@ export default function AdminDashboard({
                     const isEditing = editDraft?.dispenserId === dispenser.id;
 
                     if (isEditing && editDraft) {
+                      const currentImageUrl =
+                        !editDraft.removeImage && !editDraft.imageFile
+                          ? dispenser.imageUrl ?? null
+                          : null;
+                      const removeButtonLabel = editDraft.imageFile
+                        ? "Clear Selected Image"
+                        : editDraft.removeImage
+                          ? "Undo Remove Image"
+                          : "Remove Image";
+                      const canManageImage =
+                        editDraft.hasImage || Boolean(editDraft.imageFile) || editDraft.removeImage;
+
                       return (
                         <article
                           key={`${selectedBuilding.id}:${dispenser.id}`}
@@ -825,6 +1042,53 @@ export default function AdminDashboard({
                                 </option>
                               ))}
                             </select>
+                            <div className="rounded-lg border border-dashed border-[#ccb7e8] bg-white px-3 py-2">
+                              {currentImageUrl ? (
+                                /* eslint-disable-next-line @next/next/no-img-element */
+                                <img
+                                  src={currentImageUrl}
+                                  alt={`${dispenser.locationDescription} dispenser`}
+                                  className="mb-2 h-24 w-full rounded-md border border-[#d8cdea] object-cover"
+                                />
+                              ) : null}
+                              {editDraft.removeImage ? (
+                                <p className="mb-2 text-xs font-medium text-[#912b35]">
+                                  Image will be removed after save.
+                                </p>
+                              ) : null}
+                              {editDraft.imageFile ? (
+                                <p className="mb-2 text-xs font-medium text-[#2f5b45]">
+                                  New image: {editDraft.imageFile.name}
+                                </p>
+                              ) : null}
+                              {!currentImageUrl &&
+                              !editDraft.removeImage &&
+                              !editDraft.imageFile ? (
+                                <p className="mb-2 text-xs text-[#6c5f84]">
+                                  No image uploaded yet.
+                                </p>
+                              ) : null}
+                              <input
+                                type="file"
+                                accept={IMAGE_INPUT_ACCEPT}
+                                onChange={(event) =>
+                                  handleEditImageChange(event, dispenser.id)
+                                }
+                                aria-label={`Replace image for ${dispenser.locationDescription}`}
+                                className="w-full text-sm text-[#4a3a66] file:mr-3 file:rounded-lg file:border-0 file:bg-[#efe6fd] file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-[#4a2d76] hover:file:bg-[#e2d4fb]"
+                              />
+                              <div className="mt-2 flex flex-wrap gap-2">
+                                <button
+                                  type="button"
+                                  onClick={() => handleToggleEditImageRemoval(dispenser.id)}
+                                  disabled={!canManageImage || isPending}
+                                  aria-label={`Toggle image removal for ${dispenser.locationDescription}`}
+                                  className="rounded-lg border border-[#d4c6e8] bg-white px-3 py-1.5 text-xs font-semibold text-[#4a2d76] transition hover:border-[#b79adf] disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                  {removeButtonLabel}
+                                </button>
+                              </div>
+                            </div>
 
                             <div className="mt-3 flex flex-wrap gap-2">
                               <button
@@ -864,6 +1128,18 @@ export default function AdminDashboard({
                         key={`${selectedBuilding.id}:${dispenser.id}`}
                         className="rounded-xl border border-[#dfd3ef] bg-[#fcfbff] p-3"
                       >
+                        {dispenser.imageUrl ? (
+                          /* eslint-disable-next-line @next/next/no-img-element */
+                          <img
+                            src={dispenser.imageUrl}
+                            alt={`${dispenser.locationDescription} dispenser`}
+                            className="mb-2 h-24 w-full rounded-lg border border-[#d8cdea] object-cover"
+                          />
+                        ) : (
+                          <div className="mb-2 flex h-24 w-full items-center justify-center rounded-lg border border-dashed border-[#d8cdea] bg-[#f6f0ff] text-xs font-medium text-[#6c5f84]">
+                            No image uploaded
+                          </div>
+                        )}
                         <h3 className="font-semibold text-[#2f2050]">
                           {dispenser.locationDescription}
                         </h3>

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -213,10 +213,20 @@ export default function AdminDashboard({
           onSuccess?.();
           router.refresh();
         } catch (error) {
+          const errorMessage =
+            error instanceof Error
+              ? error.message
+              : typeof error === "object" &&
+                  error !== null &&
+                  "message" in error &&
+                  typeof (error as { message?: unknown }).message === "string"
+                ? (error as { message: string }).message
+                : "Unknown error";
+
           console.error("[wmw-usm]", {
             area: "admin_dashboard",
             operation: "run_mutation",
-            message: error instanceof Error ? error.message : "Unknown error",
+            message: errorMessage,
           });
           setMessage("error", DEFAULT_MUTATION_ERROR_MESSAGE);
         }

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -24,8 +24,10 @@ import {
 } from "@/app/admin/actions";
 import {
   DISPENSER_IMAGE_ALLOWED_MIME_TYPES,
+  DISPENSER_IMAGE_MAX_COUNT,
   DISPENSER_IMAGE_MAX_BYTES,
 } from "@/lib/dispenser-images";
+import DispenserImageSlider from "@/components/ui/DispenserImageSlider";
 import { MAINTENANCE_WRITE_OPTIONS } from "@/lib/admin/payload";
 import {
   COLD_WATER_STATUS_OPTIONS,
@@ -49,9 +51,9 @@ type EditDraft = {
   dispenserId: string;
   fields: DispenserMutationFields;
   original: DispenserMutationFields;
-  hasImage: boolean;
-  imageFile: File | null;
-  removeImage: boolean;
+  hasImages: boolean;
+  imageFiles: File[];
+  removeImages: boolean;
 };
 
 type PinWorkflow = "edit-existing" | "add-new";
@@ -65,17 +67,23 @@ const DEFAULT_MUTATION_ERROR_MESSAGE =
 const IMAGE_INPUT_ACCEPT = DISPENSER_IMAGE_ALLOWED_MIME_TYPES.join(",");
 const IMAGE_MAX_MB = Math.floor(DISPENSER_IMAGE_MAX_BYTES / (1024 * 1024));
 
-function validateImageFile(file: File): string | null {
-  if (
-    !DISPENSER_IMAGE_ALLOWED_MIME_TYPES.includes(
-      file.type as (typeof DISPENSER_IMAGE_ALLOWED_MIME_TYPES)[number]
-    )
-  ) {
-    return "Unsupported image format. Use JPEG, PNG, or WEBP.";
-  }
+function toSelectedFiles(input: FileList | null): File[] {
+  return input ? Array.from(input) : [];
+}
 
-  if (file.size > DISPENSER_IMAGE_MAX_BYTES) {
-    return `Image size must be ${IMAGE_MAX_MB} MB or less.`;
+function validateImageFiles(files: File[]): string | null {
+  for (const file of files) {
+    if (
+      !DISPENSER_IMAGE_ALLOWED_MIME_TYPES.includes(
+        file.type as (typeof DISPENSER_IMAGE_ALLOWED_MIME_TYPES)[number]
+      )
+    ) {
+      return "Unsupported image format. Use JPEG, PNG, or WEBP.";
+    }
+
+    if (file.size > DISPENSER_IMAGE_MAX_BYTES) {
+      return `Image size must be ${IMAGE_MAX_MB} MB or less.`;
+    }
   }
 
   return null;
@@ -139,7 +147,7 @@ export default function AdminDashboard({
     buildings[0]?.id ?? null
   );
   const [newFields, setNewFields] = useState<DispenserMutationFields>(initialFields);
-  const [newImageFile, setNewImageFile] = useState<File | null>(null);
+  const [newImageFiles, setNewImageFiles] = useState<File[]>([]);
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [pinWorkflow, setPinWorkflow] = useState<PinWorkflow>("edit-existing");
   const [newBuildingName, setNewBuildingName] = useState("");
@@ -162,8 +170,8 @@ export default function AdminDashboard({
 
     return (
       !areDispenserFieldsEqual(editDraft.fields, editDraft.original) ||
-      Boolean(editDraft.imageFile) ||
-      editDraft.removeImage
+      editDraft.imageFiles.length > 0 ||
+      editDraft.removeImages
     );
   }, [editDraft]);
 
@@ -299,11 +307,19 @@ export default function AdminDashboard({
       maintenanceStatus: normalizeMaintenanceStatus(newFields.maintenanceStatus),
     };
 
-    const selectedImage = newImageFile;
-    if (selectedImage) {
-      const imageValidationMessage = validateImageFile(selectedImage);
+    const selectedImages = newImageFiles;
+    if (selectedImages.length > 0) {
+      const imageValidationMessage = validateImageFiles(selectedImages);
       if (imageValidationMessage) {
         setMessage("error", imageValidationMessage);
+        return;
+      }
+
+      if (selectedImages.length > DISPENSER_IMAGE_MAX_COUNT) {
+        setMessage(
+          "error",
+          `Maximum ${DISPENSER_IMAGE_MAX_COUNT} images are allowed per dispenser.`
+        );
         return;
       }
     }
@@ -315,7 +331,7 @@ export default function AdminDashboard({
           return createResult;
         }
 
-        if (!selectedImage) {
+        if (selectedImages.length === 0) {
           return createResult;
         }
 
@@ -330,7 +346,9 @@ export default function AdminDashboard({
         const imageFormData = new FormData();
         imageFormData.append("buildingId", buildingId);
         imageFormData.append("dispenserId", createResult.dispenserId);
-        imageFormData.append("image", selectedImage);
+        for (const imageFile of selectedImages) {
+          imageFormData.append("images", imageFile);
+        }
 
         const imageResult = await uploadDispenserImage(imageFormData);
         if (!imageResult.ok) {
@@ -339,12 +357,12 @@ export default function AdminDashboard({
 
         return {
           ok: true,
-          message: "Dispenser and image saved successfully.",
+          message: "Dispenser and images saved successfully.",
         };
       },
       () => {
         setNewFields(initialFields());
-        setNewImageFile(null);
+        setNewImageFiles([]);
         if (newImageInputRef.current) {
           newImageInputRef.current.value = "";
         }
@@ -366,9 +384,9 @@ export default function AdminDashboard({
       dispenserId: dispenser.id,
       fields: nextFields,
       original: nextFields,
-      hasImage: Boolean(dispenser.imagePath),
-      imageFile: null,
-      removeImage: false,
+      hasImages: dispenser.imagePaths.length > 0,
+      imageFiles: [],
+      removeImages: false,
     });
   };
 
@@ -383,17 +401,35 @@ export default function AdminDashboard({
       return;
     }
     const buildingId = selectedBuildingId;
+    const currentDispenser = selectedBuilding?.dispensers.find(
+      (dispenser) => dispenser.id === dispenserId
+    );
+    if (!currentDispenser) {
+      setMessage("error", "Pick a dispenser to update.");
+      return;
+    }
 
     const maintenanceStatus = normalizeMaintenanceStatus(
       editDraft.fields.maintenanceStatus
     );
-    const replacementImage = editDraft.imageFile;
-    const shouldRemoveImage = editDraft.removeImage;
+    const imagesToUpload = editDraft.imageFiles;
+    const shouldRemoveImages = editDraft.removeImages;
 
-    if (replacementImage) {
-      const imageValidationMessage = validateImageFile(replacementImage);
+    if (imagesToUpload.length > 0) {
+      const imageValidationMessage = validateImageFiles(imagesToUpload);
       if (imageValidationMessage) {
         setMessage("error", imageValidationMessage);
+        return;
+      }
+
+      const existingImageCount = shouldRemoveImages
+        ? 0
+        : currentDispenser.imagePaths.length;
+      if (existingImageCount + imagesToUpload.length > DISPENSER_IMAGE_MAX_COUNT) {
+        setMessage(
+          "error",
+          `Maximum ${DISPENSER_IMAGE_MAX_COUNT} images are allowed per dispenser.`
+        );
         return;
       }
     }
@@ -411,7 +447,7 @@ export default function AdminDashboard({
           return updateResult;
         }
 
-        if (shouldRemoveImage) {
+        if (shouldRemoveImages) {
           const removeResult = await removeDispenserImage({
             buildingId,
             dispenserId,
@@ -422,11 +458,13 @@ export default function AdminDashboard({
           }
         }
 
-        if (replacementImage) {
+        if (imagesToUpload.length > 0) {
           const imageFormData = new FormData();
           imageFormData.append("buildingId", buildingId);
           imageFormData.append("dispenserId", dispenserId);
-          imageFormData.append("image", replacementImage);
+          for (const imageFile of imagesToUpload) {
+            imageFormData.append("images", imageFile);
+          }
 
           const uploadResult = await uploadDispenserImage(imageFormData);
           if (!uploadResult.ok) {
@@ -434,12 +472,12 @@ export default function AdminDashboard({
           }
         }
 
-        if (replacementImage) {
-          return { ok: true, message: "Dispenser updated and image replaced." };
+        if (imagesToUpload.length > 0) {
+          return { ok: true, message: "Dispenser updated and images added." };
         }
 
-        if (shouldRemoveImage) {
-          return { ok: true, message: "Dispenser updated and image removed." };
+        if (shouldRemoveImages) {
+          return { ok: true, message: "Dispenser updated and images removed." };
         }
 
         return updateResult;
@@ -455,21 +493,20 @@ export default function AdminDashboard({
   };
 
   const handleNewImageChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0] ?? null;
-    setNewImageFile(file);
+    setNewImageFiles(toSelectedFiles(event.target.files));
   };
 
   const handleEditImageChange = (
     event: ChangeEvent<HTMLInputElement>,
     dispenserId: string
   ) => {
-    const file = event.target.files?.[0] ?? null;
+    const files = toSelectedFiles(event.target.files);
     setEditDraft((current) =>
       current && current.dispenserId === dispenserId
         ? {
             ...current,
-            imageFile: file,
-            removeImage: file ? false : current.removeImage,
+            imageFiles: files,
+            removeImages: files.length > 0 ? false : current.removeImages,
           }
         : current
     );
@@ -481,20 +518,20 @@ export default function AdminDashboard({
         return current;
       }
 
-      if (current.imageFile) {
+      if (current.imageFiles.length > 0) {
         return {
           ...current,
-          imageFile: null,
+          imageFiles: [],
         };
       }
 
-      if (!current.hasImage) {
+      if (!current.hasImages) {
         return current;
       }
 
       return {
         ...current,
-        removeImage: !current.removeImage,
+        removeImages: !current.removeImages,
       };
     });
   };
@@ -895,17 +932,20 @@ export default function AdminDashboard({
                       id="new-dispenser-image"
                       ref={newImageInputRef}
                       type="file"
+                      multiple
                       accept={IMAGE_INPUT_ACCEPT}
                       onChange={handleNewImageChange}
-                      aria-label="Upload image for new dispenser"
+                      aria-label="Upload images for new dispenser"
                       className="w-full text-sm text-[#4a3a66] file:mr-3 file:rounded-lg file:border-0 file:bg-[#efe6fd] file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-[#4a2d76] hover:file:bg-[#e2d4fb]"
                     />
                     <p className="mt-1 text-xs text-[#6c5f84]">
-                      JPEG, PNG, or WEBP up to {IMAGE_MAX_MB} MB.
+                      JPEG, PNG, or WEBP up to {IMAGE_MAX_MB} MB each. Maximum{" "}
+                      {DISPENSER_IMAGE_MAX_COUNT} images.
                     </p>
-                    {newImageFile ? (
+                    {newImageFiles.length > 0 ? (
                       <p className="mt-1 text-xs font-medium text-[#2f5b45]">
-                        Selected: {newImageFile.name}
+                        Selected ({newImageFiles.length}):{" "}
+                        {newImageFiles.map((file) => file.name).join(", ")}
                       </p>
                     ) : null}
                   </div>
@@ -938,17 +978,18 @@ export default function AdminDashboard({
                     const isEditing = editDraft?.dispenserId === dispenser.id;
 
                     if (isEditing && editDraft) {
-                      const currentImageUrl =
-                        !editDraft.removeImage && !editDraft.imageFile
-                          ? dispenser.imageUrl ?? null
-                          : null;
-                      const removeButtonLabel = editDraft.imageFile
-                        ? "Clear Selected Image"
-                        : editDraft.removeImage
-                          ? "Undo Remove Image"
-                          : "Remove Image";
+                      const currentImageUrls = editDraft.removeImages
+                        ? []
+                        : dispenser.imageUrls;
+                      const removeButtonLabel = editDraft.imageFiles.length > 0
+                        ? "Clear Selected Images"
+                        : editDraft.removeImages
+                          ? "Undo Remove Images"
+                          : "Remove All Images";
                       const canManageImage =
-                        editDraft.hasImage || Boolean(editDraft.imageFile) || editDraft.removeImage;
+                        editDraft.hasImages ||
+                        editDraft.imageFiles.length > 0 ||
+                        editDraft.removeImages;
 
                       return (
                         <article
@@ -1053,38 +1094,33 @@ export default function AdminDashboard({
                               ))}
                             </select>
                             <div className="rounded-lg border border-dashed border-[#ccb7e8] bg-white px-3 py-2">
-                              {currentImageUrl ? (
-                                /* eslint-disable-next-line @next/next/no-img-element */
-                                <img
-                                  src={currentImageUrl}
-                                  alt={`${dispenser.locationDescription} dispenser`}
-                                  className="mb-2 h-24 w-full rounded-md border border-[#d8cdea] object-cover"
-                                />
-                              ) : null}
-                              {editDraft.removeImage ? (
+                              <DispenserImageSlider
+                                imageUrls={currentImageUrls}
+                                alt={`${dispenser.locationDescription} dispenser`}
+                                emptyLabel="No image uploaded yet."
+                                className="relative mb-2 h-24 w-full overflow-hidden rounded-md border border-[#d8cdea] bg-[#f6f0ff]"
+                                imageClassName="h-full w-full object-cover"
+                                emptyClassName="mb-2 flex h-24 w-full items-center justify-center rounded-md border border-dashed border-[#d8cdea] bg-[#f6f0ff] text-xs text-[#6c5f84]"
+                              />
+                              {editDraft.removeImages ? (
                                 <p className="mb-2 text-xs font-medium text-[#912b35]">
-                                  Image will be removed after save.
+                                  All images will be removed after save.
                                 </p>
                               ) : null}
-                              {editDraft.imageFile ? (
+                              {editDraft.imageFiles.length > 0 ? (
                                 <p className="mb-2 text-xs font-medium text-[#2f5b45]">
-                                  New image: {editDraft.imageFile.name}
-                                </p>
-                              ) : null}
-                              {!currentImageUrl &&
-                              !editDraft.removeImage &&
-                              !editDraft.imageFile ? (
-                                <p className="mb-2 text-xs text-[#6c5f84]">
-                                  No image uploaded yet.
+                                  New images ({editDraft.imageFiles.length}):{" "}
+                                  {editDraft.imageFiles.map((file) => file.name).join(", ")}
                                 </p>
                               ) : null}
                               <input
                                 type="file"
+                                multiple
                                 accept={IMAGE_INPUT_ACCEPT}
                                 onChange={(event) =>
                                   handleEditImageChange(event, dispenser.id)
                                 }
-                                aria-label={`Replace image for ${dispenser.locationDescription}`}
+                                aria-label={`Add images for ${dispenser.locationDescription}`}
                                 className="w-full text-sm text-[#4a3a66] file:mr-3 file:rounded-lg file:border-0 file:bg-[#efe6fd] file:px-3 file:py-1.5 file:text-xs file:font-semibold file:text-[#4a2d76] hover:file:bg-[#e2d4fb]"
                               />
                               <div className="mt-2 flex flex-wrap gap-2">
@@ -1138,18 +1174,14 @@ export default function AdminDashboard({
                         key={`${selectedBuilding.id}:${dispenser.id}`}
                         className="rounded-xl border border-[#dfd3ef] bg-[#fcfbff] p-3"
                       >
-                        {dispenser.imageUrl ? (
-                          /* eslint-disable-next-line @next/next/no-img-element */
-                          <img
-                            src={dispenser.imageUrl}
-                            alt={`${dispenser.locationDescription} dispenser`}
-                            className="mb-2 h-24 w-full rounded-lg border border-[#d8cdea] object-cover"
-                          />
-                        ) : (
-                          <div className="mb-2 flex h-24 w-full items-center justify-center rounded-lg border border-dashed border-[#d8cdea] bg-[#f6f0ff] text-xs font-medium text-[#6c5f84]">
-                            No image uploaded
-                          </div>
-                        )}
+                        <DispenserImageSlider
+                          imageUrls={dispenser.imageUrls}
+                          alt={`${dispenser.locationDescription} dispenser`}
+                          emptyLabel="No image uploaded"
+                          className="relative mb-2 h-24 w-full overflow-hidden rounded-lg border border-[#d8cdea] bg-[#f6f0ff]"
+                          imageClassName="h-full w-full object-cover"
+                          emptyClassName="mb-2 flex h-24 w-full items-center justify-center rounded-lg border border-dashed border-[#d8cdea] bg-[#f6f0ff] text-xs font-medium text-[#6c5f84]"
+                        />
                         <h3 className="font-semibold text-[#2f2050]">
                           {dispenser.locationDescription}
                         </h3>

--- a/components/ui/DispenserImageSlider.tsx
+++ b/components/ui/DispenserImageSlider.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { type KeyboardEvent, useId, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface DispenserImageSliderProps {
+  imageUrls: string[];
+  alt: string;
+  emptyLabel: string;
+  className: string;
+  imageClassName: string;
+  emptyClassName: string;
+}
+
+function clampIndex(index: number, length: number) {
+  if (length === 0) {
+    return 0;
+  }
+
+  if (index < 0) {
+    return length - 1;
+  }
+
+  if (index >= length) {
+    return 0;
+  }
+
+  return index;
+}
+
+export default function DispenserImageSlider({
+  imageUrls,
+  alt,
+  emptyLabel,
+  className,
+  imageClassName,
+  emptyClassName,
+}: DispenserImageSliderProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const regionId = useId();
+  const hasImages = imageUrls.length > 0;
+  const hasMultiple = imageUrls.length > 1;
+  const currentIndex = clampIndex(activeIndex, imageUrls.length);
+
+  const goToPrevious = () => {
+    setActiveIndex((current) => clampIndex(current - 1, imageUrls.length));
+  };
+
+  const goToNext = () => {
+    setActiveIndex((current) => clampIndex(current + 1, imageUrls.length));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!hasMultiple) {
+      return;
+    }
+
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      goToPrevious();
+      return;
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      goToNext();
+    }
+  };
+
+  if (!hasImages) {
+    return (
+      <div className={emptyClassName} aria-label={emptyLabel}>
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      tabIndex={hasMultiple ? 0 : -1}
+      onKeyDown={handleKeyDown}
+      aria-roledescription={hasMultiple ? "carousel" : undefined}
+      aria-label={`${alt} images`}
+      aria-describedby={hasMultiple ? regionId : undefined}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={imageUrls[currentIndex]} alt={alt} className={imageClassName} />
+
+      {hasMultiple ? (
+        <>
+          <button
+            type="button"
+            onClick={goToPrevious}
+            aria-label="Previous dispenser image"
+            className="absolute top-1/2 left-2 -translate-y-1/2 rounded-full border border-[#d8cdea] bg-white/90 p-1 text-[#4a2d76] transition hover:bg-white"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={goToNext}
+            aria-label="Next dispenser image"
+            className="absolute top-1/2 right-2 -translate-y-1/2 rounded-full border border-[#d8cdea] bg-white/90 p-1 text-[#4a2d76] transition hover:bg-white"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+          <div
+            id={regionId}
+            className="pointer-events-none absolute right-0 bottom-2 left-0 flex items-center justify-center gap-1"
+          >
+            {imageUrls.map((_, index) => (
+              <button
+                key={`${alt}:${index}`}
+                type="button"
+                onClick={() => setActiveIndex(index)}
+                aria-label={`View dispenser image ${index + 1}`}
+                className={`pointer-events-auto h-1.5 w-1.5 rounded-full transition ${
+                  index === currentIndex ? "bg-white" : "bg-white/55"
+                }`}
+              />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/components/ui/Sidebar.test.tsx
+++ b/components/ui/Sidebar.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import Sidebar from "@/components/ui/Sidebar";
 import type { Building } from "@/lib/types";
 
@@ -11,10 +11,14 @@ const BUILDING: Building = {
   dispensers: [],
 };
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("Sidebar", () => {
   it("renders mobile close button and calls onClose when clicked", () => {
     const onClose = vi.fn();
-    render(<Sidebar building={BUILDING} onClose={onClose} />);
+    render(<Sidebar building={BUILDING} onClose={onClose} userLocation={null} />);
 
     const closeButton = screen.getByRole("button", {
       name: "Close building details sheet",
@@ -24,7 +28,7 @@ describe("Sidebar", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("renders dispenser image when imageUrl exists", () => {
+  it("renders dispenser image when imageUrls exist", () => {
     render(
       <Sidebar
         building={{
@@ -37,7 +41,8 @@ describe("Sidebar", () => {
               brand: "Coway",
               coldWaterStatus: "Available",
               maintenanceStatus: "Operational",
-              imageUrl: "https://cdn.test/pantry.jpg",
+              imagePaths: ["bld-1/dsp-1/pantry.jpg"],
+              imageUrls: ["https://cdn.test/pantry.jpg"],
             },
           ],
         }}
@@ -62,6 +67,8 @@ describe("Sidebar", () => {
               brand: "Coway",
               coldWaterStatus: "Available",
               maintenanceStatus: "Operational",
+              imagePaths: [],
+              imageUrls: [],
             },
           ],
         }}
@@ -71,5 +78,38 @@ describe("Sidebar", () => {
     );
 
     expect(screen.getAllByText("No Image").length).toBeGreaterThan(0);
+  });
+
+  it("slides through multiple dispenser images", () => {
+    render(
+      <Sidebar
+        building={{
+          ...BUILDING,
+          dispensers: [
+            {
+              id: "dsp-1",
+              buildingId: "bld-1",
+              locationDescription: "Pantry",
+              brand: "Coway",
+              coldWaterStatus: "Available",
+              maintenanceStatus: "Operational",
+              imagePaths: ["bld-1/dsp-1/1.jpg", "bld-1/dsp-1/2.jpg"],
+              imageUrls: ["https://cdn.test/1.jpg", "https://cdn.test/2.jpg"],
+            },
+          ],
+        }}
+        onClose={vi.fn()}
+        userLocation={null}
+      />
+    );
+
+    const image = screen.getAllByAltText("Pantry dispenser")[0];
+    expect(image).toHaveAttribute("src", "https://cdn.test/1.jpg");
+
+    fireEvent.click(screen.getAllByLabelText("Next dispenser image")[0]);
+    expect(screen.getAllByAltText("Pantry dispenser")[0]).toHaveAttribute(
+      "src",
+      "https://cdn.test/2.jpg"
+    );
   });
 });

--- a/components/ui/Sidebar.test.tsx
+++ b/components/ui/Sidebar.test.tsx
@@ -23,4 +23,53 @@ describe("Sidebar", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("renders dispenser image when imageUrl exists", () => {
+    render(
+      <Sidebar
+        building={{
+          ...BUILDING,
+          dispensers: [
+            {
+              id: "dsp-1",
+              buildingId: "bld-1",
+              locationDescription: "Pantry",
+              brand: "Coway",
+              coldWaterStatus: "Available",
+              maintenanceStatus: "Operational",
+              imageUrl: "https://cdn.test/pantry.jpg",
+            },
+          ],
+        }}
+        onClose={vi.fn()}
+        userLocation={null}
+      />
+    );
+
+    expect(screen.getAllByAltText("Pantry dispenser").length).toBeGreaterThan(0);
+  });
+
+  it("renders image placeholder when dispenser image is missing", () => {
+    render(
+      <Sidebar
+        building={{
+          ...BUILDING,
+          dispensers: [
+            {
+              id: "dsp-1",
+              buildingId: "bld-1",
+              locationDescription: "Pantry",
+              brand: "Coway",
+              coldWaterStatus: "Available",
+              maintenanceStatus: "Operational",
+            },
+          ],
+        }}
+        onClose={vi.fn()}
+        userLocation={null}
+      />
+    );
+
+    expect(screen.getAllByText("No Image").length).toBeGreaterThan(0);
+  });
 });

--- a/components/ui/Sidebar.tsx
+++ b/components/ui/Sidebar.tsx
@@ -113,10 +113,10 @@ function DispenserList({ building }: { building: Building }) {
             <img
               src={dispenser.imageUrl}
               alt={`${dispenser.locationDescription} dispenser`}
-              className="mb-3 h-28 w-full rounded-xl border border-[#e2d8f0] object-cover"
+              className="mb-3 aspect-square w-full rounded-xl border border-[#e2d8f0] object-cover"
             />
           ) : (
-            <div className="mb-3 flex h-28 w-full items-center justify-center rounded-xl border border-dashed border-[#d8cdea] bg-[#f8f3ff] text-xs font-semibold tracking-wide text-[#6c5f84] uppercase">
+            <div className="mb-3 flex aspect-square w-full items-center justify-center rounded-xl border border-dashed border-[#d8cdea] bg-[#f8f3ff] text-xs font-semibold tracking-wide text-[#6c5f84] uppercase">
               No Image
             </div>
           )}
@@ -378,6 +378,10 @@ export default function Sidebar({ building, onClose, userLocation }: SidebarProp
           {!isPeek && (
             <div className="min-h-0 flex-1 overflow-y-auto">
               <DispenserList building={building} />
+              <div
+                aria-hidden="true"
+                style={{ height: `${Math.max(0, effectiveTranslate)}px` }}
+              />
             </div>
           )}
         </div>

--- a/components/ui/Sidebar.tsx
+++ b/components/ui/Sidebar.tsx
@@ -108,6 +108,18 @@ function DispenserList({ building }: { building: Building }) {
           key={`${building.id}:${dispenser.id}`}
           className="rounded-2xl border border-[#d8cdea] bg-white px-4 py-4 shadow-[0_14px_28px_-30px_rgba(67,26,124,0.65)] transition hover:border-[#b79adf] md:px-5"
         >
+          {dispenser.imageUrl ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={dispenser.imageUrl}
+              alt={`${dispenser.locationDescription} dispenser`}
+              className="mb-3 h-28 w-full rounded-xl border border-[#e2d8f0] object-cover"
+            />
+          ) : (
+            <div className="mb-3 flex h-28 w-full items-center justify-center rounded-xl border border-dashed border-[#d8cdea] bg-[#f8f3ff] text-xs font-semibold tracking-wide text-[#6c5f84] uppercase">
+              No Image
+            </div>
+          )}
           <h3 className="text-lg leading-snug font-bold text-[#281947] md:text-xl">
             {dispenser.locationDescription}
           </h3>

--- a/components/ui/Sidebar.tsx
+++ b/components/ui/Sidebar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type PointerEvent } from "react";
 import { MapPin, Navigation, X } from "lucide-react";
 import type { Building } from "@/lib/types";
+import DispenserImageSlider from "@/components/ui/DispenserImageSlider";
 import { ColdWaterBadge, MaintenanceBadge } from "./StatusBadge";
 
 interface SidebarProps {
@@ -108,18 +109,14 @@ function DispenserList({ building }: { building: Building }) {
           key={`${building.id}:${dispenser.id}`}
           className="rounded-2xl border border-[#d8cdea] bg-white px-4 py-4 shadow-[0_14px_28px_-30px_rgba(67,26,124,0.65)] transition hover:border-[#b79adf] md:px-5"
         >
-          {dispenser.imageUrl ? (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img
-              src={dispenser.imageUrl}
-              alt={`${dispenser.locationDescription} dispenser`}
-              className="mb-3 aspect-square w-full rounded-xl border border-[#e2d8f0] object-cover"
-            />
-          ) : (
-            <div className="mb-3 flex aspect-square w-full items-center justify-center rounded-xl border border-dashed border-[#d8cdea] bg-[#f8f3ff] text-xs font-semibold tracking-wide text-[#6c5f84] uppercase">
-              No Image
-            </div>
-          )}
+          <DispenserImageSlider
+            imageUrls={dispenser.imageUrls}
+            alt={`${dispenser.locationDescription} dispenser`}
+            emptyLabel="No Image"
+            className="relative mb-3 aspect-square w-full overflow-hidden rounded-xl border border-[#e2d8f0] bg-[#f8f3ff]"
+            imageClassName="h-full w-full object-cover"
+            emptyClassName="mb-3 flex aspect-square w-full items-center justify-center rounded-xl border border-dashed border-[#d8cdea] bg-[#f8f3ff] text-xs font-semibold tracking-wide text-[#6c5f84] uppercase"
+          />
           <h3 className="text-lg leading-snug font-bold text-[#281947] md:text-xl">
             {dispenser.locationDescription}
           </h3>

--- a/lib/data.test.ts
+++ b/lib/data.test.ts
@@ -18,8 +18,14 @@ type QueryResult = {
   error: QueryError | null;
 };
 
-function makeClient(result: QueryResult) {
-  const order = vi.fn().mockResolvedValue(result);
+function makeClient(result: QueryResult | QueryResult[]) {
+  const results = Array.isArray(result) ? result : [result];
+  let index = 0;
+  const order = vi.fn().mockImplementation(async () => {
+    const selected = results[Math.min(index, results.length - 1)];
+    index += 1;
+    return selected;
+  });
   const select = vi.fn().mockReturnValue({ order });
   const from = vi.fn().mockReturnValue({ select });
   const getPublicUrl = vi.fn((path: string) => ({
@@ -61,6 +67,7 @@ describe("getBuildings", () => {
               brand: "Cuckoo",
               cold_water_status: "Available",
               maintenance_status: "Operational",
+              image_paths: ["bld-1/dsp-1/sample.jpg"],
               image_path: "bld-1/dsp-1/sample.jpg",
             },
           ],
@@ -86,8 +93,8 @@ describe("getBuildings", () => {
             brand: "Cuckoo",
             coldWaterStatus: "Available",
             maintenanceStatus: "Operational",
-            imagePath: "bld-1/dsp-1/sample.jpg",
-            imageUrl: "https://cdn.test/bld-1/dsp-1/sample.jpg",
+            imagePaths: ["bld-1/dsp-1/sample.jpg"],
+            imageUrls: ["https://cdn.test/bld-1/dsp-1/sample.jpg"],
           },
         ],
       },
@@ -111,6 +118,7 @@ describe("getBuildings", () => {
               brand: "Coway",
               cold_water_status: "Available",
               maintenance_status: "Out of service",
+              image_paths: [],
               image_path: null,
             },
           ],
@@ -123,6 +131,47 @@ describe("getBuildings", () => {
     const buildings = await getBuildings();
 
     expect(buildings[0]?.dispensers[0]?.maintenanceStatus).toBe("Unknown");
+  });
+
+  it("falls back to legacy image_path query when image_paths column is unavailable", async () => {
+    const client = makeClient([
+      {
+        data: null,
+        error: {
+          message: "column dispensers.image_paths does not exist",
+          code: "42703",
+        },
+      },
+      {
+        data: [
+          {
+            id: "bld-1",
+            name: "School of Computer Sciences",
+            latitude: 5.35,
+            longitude: 100.3,
+            dispensers: [
+              {
+                building_id: "bld-1",
+                dispenser_id: "dsp-1",
+                location_description: "Pantry CS",
+                brand: "Cuckoo",
+                cold_water_status: "Available",
+                maintenance_status: "Operational",
+                image_path: "bld-1/dsp-1/sample.jpg",
+              },
+            ],
+          },
+        ],
+        error: null,
+      },
+    ]);
+    createClientMock.mockReturnValue(client as never);
+
+    const buildings = await getBuildings();
+
+    expect(buildings[0]?.dispensers[0]?.imagePaths).toEqual([
+      "bld-1/dsp-1/sample.jpg",
+    ]);
   });
 
   it("logs structured details and throws a user-safe error when query fails", async () => {

--- a/lib/data.test.ts
+++ b/lib/data.test.ts
@@ -22,7 +22,16 @@ function makeClient(result: QueryResult) {
   const order = vi.fn().mockResolvedValue(result);
   const select = vi.fn().mockReturnValue({ order });
   const from = vi.fn().mockReturnValue({ select });
-  return { from };
+  const getPublicUrl = vi.fn((path: string) => ({
+    data: { publicUrl: `https://cdn.test/${path}` },
+  }));
+  const storageFrom = vi.fn().mockReturnValue({ getPublicUrl });
+  return {
+    from,
+    storage: {
+      from: storageFrom,
+    },
+  };
 }
 
 describe("getBuildings", () => {
@@ -52,6 +61,7 @@ describe("getBuildings", () => {
               brand: "Cuckoo",
               cold_water_status: "Available",
               maintenance_status: "Operational",
+              image_path: "bld-1/dsp-1/sample.jpg",
             },
           ],
         },
@@ -76,6 +86,8 @@ describe("getBuildings", () => {
             brand: "Cuckoo",
             coldWaterStatus: "Available",
             maintenanceStatus: "Operational",
+            imagePath: "bld-1/dsp-1/sample.jpg",
+            imageUrl: "https://cdn.test/bld-1/dsp-1/sample.jpg",
           },
         ],
       },
@@ -99,6 +111,7 @@ describe("getBuildings", () => {
               brand: "Coway",
               cold_water_status: "Available",
               maintenance_status: "Out of service",
+              image_path: null,
             },
           ],
         },

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { PostgrestError } from "@supabase/supabase-js";
+import { DISPENSER_IMAGE_BUCKET } from "@/lib/dispenser-images";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type { Building, ColdWaterStatus, MaintenanceStatus } from "@/lib/types";
 
@@ -11,6 +12,7 @@ type DispenserRow = {
   brand: string;
   cold_water_status: string;
   maintenance_status: string;
+  image_path: string | null;
 };
 
 type BuildingRow = {
@@ -51,7 +53,7 @@ export async function getBuildings(): Promise<Building[]> {
   const { data, error } = await supabase
     .from("buildings")
     .select(
-      "id,name,latitude,longitude,dispensers(building_id,dispenser_id,location_description,brand,cold_water_status,maintenance_status)"
+      "id,name,latitude,longitude,dispensers(building_id,dispenser_id,location_description,brand,cold_water_status,maintenance_status,image_path)"
     )
     .order("name");
 
@@ -75,13 +77,23 @@ export async function getBuildings(): Promise<Building[]> {
     name: building.name,
     latitude: building.latitude,
     longitude: building.longitude,
-    dispensers: (building.dispensers ?? []).map((dispenser) => ({
-      id: dispenser.dispenser_id,
-      buildingId: dispenser.building_id,
-      locationDescription: dispenser.location_description,
-      brand: dispenser.brand,
-      coldWaterStatus: toColdWaterStatus(dispenser.cold_water_status),
-      maintenanceStatus: toMaintenanceStatus(dispenser.maintenance_status),
-    })),
+    dispensers: (building.dispensers ?? []).map((dispenser) => {
+      const imagePath = dispenser.image_path ?? undefined;
+      const imageUrl = imagePath
+        ? supabase.storage.from(DISPENSER_IMAGE_BUCKET).getPublicUrl(imagePath).data
+            .publicUrl
+        : undefined;
+
+      return {
+        id: dispenser.dispenser_id,
+        buildingId: dispenser.building_id,
+        locationDescription: dispenser.location_description,
+        brand: dispenser.brand,
+        coldWaterStatus: toColdWaterStatus(dispenser.cold_water_status),
+        maintenanceStatus: toMaintenanceStatus(dispenser.maintenance_status),
+        imagePath,
+        imageUrl,
+      };
+    }),
   }));
 }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -12,6 +12,7 @@ type DispenserRow = {
   brand: string;
   cold_water_status: string;
   maintenance_status: string;
+  image_paths?: string[] | null;
   image_path: string | null;
 };
 
@@ -25,6 +26,10 @@ type BuildingRow = {
 
 export const BUILDINGS_LOAD_ERROR_MESSAGE =
   "Unable to load water refill data right now.";
+const BUILDINGS_SELECT_WITH_GALLERY =
+  "id,name,latitude,longitude,dispensers(building_id,dispenser_id,location_description,brand,cold_water_status,maintenance_status,image_paths,image_path)";
+const BUILDINGS_SELECT_LEGACY =
+  "id,name,latitude,longitude,dispensers(building_id,dispenser_id,location_description,brand,cold_water_status,maintenance_status,image_path)";
 
 function toColdWaterStatus(value: string): ColdWaterStatus {
   if (value === "Available" || value === "Unavailable" || value === "Unknown") {
@@ -47,15 +52,35 @@ function toMaintenanceStatus(value: string): MaintenanceStatus {
   return "Unknown";
 }
 
+function toImagePaths(dispenser: DispenserRow): string[] {
+  if (Array.isArray(dispenser.image_paths)) {
+    return dispenser.image_paths.filter(
+      (value): value is string => typeof value === "string" && value.length > 0
+    );
+  }
+
+  if (typeof dispenser.image_path === "string" && dispenser.image_path.length > 0) {
+    return [dispenser.image_path];
+  }
+
+  return [];
+}
+
+function isMissingImagePathsColumn(error: PostgrestError | null) {
+  return error?.code === "42703" && error.message.includes("image_paths");
+}
+
 export async function getBuildings(): Promise<Building[]> {
   const supabase = createSupabaseServerClient();
 
-  const { data, error } = await supabase
+  const queryWithGallery = await supabase
     .from("buildings")
-    .select(
-      "id,name,latitude,longitude,dispensers(building_id,dispenser_id,location_description,brand,cold_water_status,maintenance_status,image_path)"
-    )
+    .select(BUILDINGS_SELECT_WITH_GALLERY)
     .order("name");
+  const queryResult = isMissingImagePathsColumn(queryWithGallery.error as PostgrestError | null)
+    ? await supabase.from("buildings").select(BUILDINGS_SELECT_LEGACY).order("name")
+    : queryWithGallery;
+  const { data, error } = queryResult;
 
   if (error) {
     const typedError = error as PostgrestError | null;
@@ -78,11 +103,12 @@ export async function getBuildings(): Promise<Building[]> {
     latitude: building.latitude,
     longitude: building.longitude,
     dispensers: (building.dispensers ?? []).map((dispenser) => {
-      const imagePath = dispenser.image_path ?? undefined;
-      const imageUrl = imagePath
-        ? supabase.storage.from(DISPENSER_IMAGE_BUCKET).getPublicUrl(imagePath).data
+      const imagePaths = toImagePaths(dispenser);
+      const imageUrls = imagePaths.map(
+        (path) =>
+          supabase.storage.from(DISPENSER_IMAGE_BUCKET).getPublicUrl(path).data
             .publicUrl
-        : undefined;
+      );
 
       return {
         id: dispenser.dispenser_id,
@@ -91,8 +117,8 @@ export async function getBuildings(): Promise<Building[]> {
         brand: dispenser.brand,
         coldWaterStatus: toColdWaterStatus(dispenser.cold_water_status),
         maintenanceStatus: toMaintenanceStatus(dispenser.maintenance_status),
-        imagePath,
-        imageUrl,
+        imagePaths,
+        imageUrls,
       };
     }),
   }));

--- a/lib/dispenser-images.ts
+++ b/lib/dispenser-images.ts
@@ -1,0 +1,45 @@
+export const DISPENSER_IMAGE_BUCKET = "dispenser-images";
+export const DISPENSER_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+
+export const DISPENSER_IMAGE_ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+] as const;
+
+const MIME_EXTENSION_MAP: Record<
+  (typeof DISPENSER_IMAGE_ALLOWED_MIME_TYPES)[number],
+  string
+> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+export function isAllowedDispenserImageMimeType(
+  mimeType: string
+): mimeType is (typeof DISPENSER_IMAGE_ALLOWED_MIME_TYPES)[number] {
+  return DISPENSER_IMAGE_ALLOWED_MIME_TYPES.includes(
+    mimeType as (typeof DISPENSER_IMAGE_ALLOWED_MIME_TYPES)[number]
+  );
+}
+
+export function getDispenserImageExtension(
+  mimeType: string
+): string | null {
+  if (!isAllowedDispenserImageMimeType(mimeType)) {
+    return null;
+  }
+
+  return MIME_EXTENSION_MAP[mimeType];
+}
+
+export function buildDispenserImagePath(
+  buildingId: string,
+  dispenserId: string,
+  extension: string,
+  idGenerator: () => string = () => crypto.randomUUID()
+) {
+  const fileName = `${idGenerator()}.${extension}`;
+  return `${buildingId}/${dispenserId}/${fileName}`;
+}

--- a/lib/dispenser-images.ts
+++ b/lib/dispenser-images.ts
@@ -1,5 +1,6 @@
 export const DISPENSER_IMAGE_BUCKET = "dispenser-images";
 export const DISPENSER_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+export const DISPENSER_IMAGE_MAX_COUNT = 8;
 
 export const DISPENSER_IMAGE_ALLOWED_MIME_TYPES = [
   "image/jpeg",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,6 +25,8 @@ export interface Dispenser {
   brand: string;
   coldWaterStatus: ColdWaterStatus;
   maintenanceStatus: MaintenanceStatus;
+  imagePath?: string;
+  imageUrl?: string;
 }
 
 export interface Building {
@@ -71,6 +73,10 @@ export interface UpdateBuildingPinPayload {
 export interface MutationResult {
   ok: boolean;
   message: string;
+}
+
+export interface CreateDispenserResult extends MutationResult {
+  dispenserId?: string;
 }
 
 export interface CreateBuildingResult extends MutationResult {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,8 +25,8 @@ export interface Dispenser {
   brand: string;
   coldWaterStatus: ColdWaterStatus;
   maintenanceStatus: MaintenanceStatus;
-  imagePath?: string;
-  imageUrl?: string;
+  imagePaths: string[];
+  imageUrls: string[];
 }
 
 export interface Building {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["10.207.154.89", '10.212.242.91'],
+  allowedDevOrigins: ["10.207.154.89", "10.212.242.91"],
+  experimental: {
+    serverActions: {
+      // Image uploads are sent as multipart FormData and can exceed default action limits.
+      bodySizeLimit: "10mb",
+    },
+  },
 };
 
 export default nextConfig;

--- a/supabase/001_DB_schema.sql
+++ b/supabase/001_DB_schema.sql
@@ -20,6 +20,8 @@ create table if not exists public.dispensers (
   brand text not null,
   cold_water_status text not null,
   maintenance_status text not null,
+  image_path text,
+  image_paths text[] not null default '{}',
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now()),
   primary key (building_id, dispenser_id),

--- a/supabase/004_dispenser_images.sql
+++ b/supabase/004_dispenser_images.sql
@@ -1,0 +1,70 @@
+-- Add dispenser image support using Supabase Storage.
+
+begin;
+
+alter table public.dispensers
+add column if not exists image_path text;
+
+insert into storage.buckets (id, name, public)
+values ('dispenser-images', 'dispenser-images', true)
+on conflict (id) do update
+set public = excluded.public;
+
+drop policy if exists "Public read dispenser images" on storage.objects;
+create policy "Public read dispenser images"
+on storage.objects
+for select
+to anon, authenticated
+using (bucket_id = 'dispenser-images');
+
+drop policy if exists "Admin insert dispenser images" on storage.objects;
+create policy "Admin insert dispenser images"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'dispenser-images'
+  and exists (
+    select 1
+    from public.admin_users admin
+    where admin.email = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+drop policy if exists "Admin update dispenser images" on storage.objects;
+create policy "Admin update dispenser images"
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'dispenser-images'
+  and exists (
+    select 1
+    from public.admin_users admin
+    where admin.email = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+)
+with check (
+  bucket_id = 'dispenser-images'
+  and exists (
+    select 1
+    from public.admin_users admin
+    where admin.email = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+drop policy if exists "Admin delete dispenser images" on storage.objects;
+create policy "Admin delete dispenser images"
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'dispenser-images'
+  and exists (
+    select 1
+    from public.admin_users admin
+    where admin.email = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+commit;

--- a/supabase/005_dispenser_image_paths.sql
+++ b/supabase/005_dispenser_image_paths.sql
@@ -1,0 +1,13 @@
+-- Support multiple dispenser images per dispenser row.
+
+begin;
+
+alter table public.dispensers
+add column if not exists image_paths text[] not null default '{}';
+
+update public.dispensers
+set image_paths = array[image_path]
+where image_path is not null
+  and cardinality(image_paths) = 0;
+
+commit;


### PR DESCRIPTION

- Add admin support to upload, replace, and remove dispenser images.
- Show dispenser images on user cards as smaller square thumbnails (with placeholder).
- Fix mobile half-open sidebar so content can scroll fully to the bottom.
- Increase Next.js server action body size limit for image uploads.