### PR TITLE
Real-time user tracking with distance/time gating

### DIFF
--- a/components/ui/Map.test.tsx
+++ b/components/ui/Map.test.tsx
@@ -1,10 +1,13 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import Map from "@/components/ui/Map";
 import type { Building } from "@/lib/types";
 
 const flyToMock = vi.fn();
+const watchPositionMock = vi.fn();
+const clearWatchMock = vi.fn();
+const GEOLOCATION_WATCH_ID = 91;
 const mockedLeafletMap = {
   flyTo: flyToMock,
   getSize: () => ({ x: 1280, y: 720 }),
@@ -80,6 +83,35 @@ const BUILDINGS: Building[] = [
   },
 ];
 
+let geolocationSuccessHandler: PositionCallback | null = null;
+
+function createMockPosition(lat: number, lng: number): GeolocationPosition {
+  return {
+    coords: {
+      latitude: lat,
+      longitude: lng,
+      accuracy: 6,
+      altitude: null,
+      altitudeAccuracy: null,
+      heading: null,
+      speed: null,
+      toJSON: () => ({}),
+    },
+    timestamp: 0,
+    toJSON: () => ({}),
+  };
+}
+
+function emitGeolocationSuccess(lat: number, lng: number) {
+  if (!geolocationSuccessHandler) {
+    throw new Error("Geolocation success callback is not registered.");
+  }
+
+  act(() => {
+    geolocationSuccessHandler?.(createMockPosition(lat, lng));
+  });
+}
+
 describe("Map marker nearest-state rendering", () => {
   afterEach(() => {
     cleanup();
@@ -99,10 +131,26 @@ describe("Map marker nearest-state rendering", () => {
         dispatchEvent: vi.fn(),
       })),
     });
+
+    Object.defineProperty(window.navigator, "geolocation", {
+      configurable: true,
+      value: {
+        watchPosition: watchPositionMock,
+        clearWatch: clearWatchMock,
+      },
+    });
   });
 
   beforeEach(() => {
     flyToMock.mockClear();
+    watchPositionMock.mockReset();
+    clearWatchMock.mockReset();
+    geolocationSuccessHandler = null;
+
+    watchPositionMock.mockImplementation((success: PositionCallback) => {
+      geolocationSuccessHandler = success;
+      return GEOLOCATION_WATCH_ID;
+    });
   });
 
   it("applies nearest marker ring style to the nearest building marker", () => {
@@ -141,5 +189,170 @@ describe("Map marker nearest-state rendering", () => {
 
     expect(html).toContain("rgba(13,148,136,0.95)");
     expect(html).toContain("#EB8423");
+  });
+
+  it("starts geolocation watch when map is ready", () => {
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={vi.fn()}
+      />
+    );
+
+    expect(watchPositionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears geolocation watch on unmount", () => {
+    const { unmount } = render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={vi.fn()}
+      />
+    );
+
+    unmount();
+
+    expect(clearWatchMock).toHaveBeenCalledWith(GEOLOCATION_WATCH_ID);
+  });
+
+  it("accepts first position update and centers camera once", () => {
+    const onUserLocationChange = vi.fn();
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValue(1_000);
+
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={onUserLocationChange}
+      />
+    );
+
+    const flyToCountBeforeFirstFix = flyToMock.mock.calls.length;
+
+    emitGeolocationSuccess(5.3561, 100.2991);
+
+    expect(onUserLocationChange).toHaveBeenCalledTimes(1);
+    expect(flyToMock.mock.calls.length).toBe(flyToCountBeforeFirstFix + 1);
+    expect(flyToMock).toHaveBeenLastCalledWith([5.3561, 100.2991], 19, { duration: 1.2 });
+
+    nowSpy.mockRestore();
+  });
+
+  it("ignores updates when movement is below 8 meters", () => {
+    const onUserLocationChange = vi.fn();
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValueOnce(1_000).mockReturnValueOnce(7_000);
+
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={onUserLocationChange}
+      />
+    );
+
+    emitGeolocationSuccess(5.3561, 100.2991);
+    emitGeolocationSuccess(5.35613, 100.2991);
+
+    expect(onUserLocationChange).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockRestore();
+  });
+
+  it("ignores updates above 8 meters when less than 5 seconds have elapsed", () => {
+    const onUserLocationChange = vi.fn();
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValueOnce(1_000).mockReturnValueOnce(4_000);
+
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={onUserLocationChange}
+      />
+    );
+
+    emitGeolocationSuccess(5.3561, 100.2991);
+    emitGeolocationSuccess(5.3562, 100.2991);
+
+    expect(onUserLocationChange).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockRestore();
+  });
+
+  it("accepts updates above 8 meters after at least 5 seconds", () => {
+    const onUserLocationChange = vi.fn();
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValueOnce(1_000).mockReturnValueOnce(7_000);
+
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={onUserLocationChange}
+      />
+    );
+
+    emitGeolocationSuccess(5.3561, 100.2991);
+    emitGeolocationSuccess(5.3562, 100.2991);
+
+    expect(onUserLocationChange).toHaveBeenCalledTimes(2);
+    expect(onUserLocationChange).toHaveBeenNthCalledWith(2, { lat: 5.3562, lng: 100.2991 });
+
+    nowSpy.mockRestore();
+  });
+
+  it("does not auto-follow the camera after the first accepted position", () => {
+    const onUserLocationChange = vi.fn();
+    const nowSpy = vi.spyOn(Date, "now");
+
+    nowSpy.mockReturnValueOnce(1_000).mockReturnValueOnce(7_000);
+
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={onUserLocationChange}
+      />
+    );
+
+    emitGeolocationSuccess(5.3561, 100.2991);
+
+    const flyToCountAfterFirstFix = flyToMock.mock.calls.length;
+
+    emitGeolocationSuccess(5.3562, 100.2991);
+
+    expect(onUserLocationChange).toHaveBeenCalledTimes(2);
+    expect(flyToMock.mock.calls.length).toBe(flyToCountAfterFirstFix);
+
+    nowSpy.mockRestore();
   });
 });

--- a/components/ui/Map.tsx
+++ b/components/ui/Map.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MapContainer, Marker, TileLayer, useMap, ZoomControl } from "react-leaflet";
 import { DivIcon, type LatLngBoundsExpression, type Map as LeafletMap } from "leaflet";
 import "leaflet/dist/leaflet.css";
+import { haversineDistanceMeters } from "@/lib/nearest";
 import type { Building, LatLng } from "@/lib/types";
 
 interface MapProps {
@@ -24,6 +25,13 @@ const MAP_MIN_ZOOM = 17;
 const MAP_MAX_ZOOM = 19;
 const MOBILE_BREAKPOINT_PX = 768;
 const MOBILE_FOCUS_Y_RATIO = 0.4;
+const LOCATION_UPDATE_MIN_DISTANCE_METERS = 8;
+const LOCATION_UPDATE_MIN_INTERVAL_MS = 5000;
+const GEOLOCATION_OPTIONS: PositionOptions = {
+  enableHighAccuracy: false,
+  timeout: 10000,
+  maximumAge: 5000,
+};
 
 function MapController({
   buildings,
@@ -65,12 +73,9 @@ function MapController({
       }
     }
 
-    if (userLocation) {
-      map.flyTo([userLocation.lat, userLocation.lng], MAP_MAX_ZOOM, { duration: 1.5 });
-      return;
+    if (!userLocation) {
+      map.flyTo(USM_CENTER, MAP_MIN_ZOOM, { duration: 1.5 });
     }
-
-    map.flyTo(USM_CENTER, MAP_MIN_ZOOM, { duration: 1.5 });
   }, [buildings, map, selectedBuildingId, userLocation]);
 
   return null;
@@ -137,52 +142,81 @@ export default function Map({
   onUserLocationChange,
 }: MapProps) {
   const [mapInstance, setMapInstance] = useState<LeafletMap | null>(null);
-  // THIS IS THE MAIN LOGIC FOR AUTO FINDING USER LOCATION
-  const locateUser = () => {
-    if (!navigator.geolocation) {
-      window.alert("Geolocation is not supported by your browser.");
+  const geolocationWatchIdRef = useRef<number | null>(null);
+  const lastAcceptedLocationRef = useRef<LatLng | null>(null);
+  const lastAcceptedTimestampRef = useRef<number | null>(null);
+  const hasCenteredOnUserRef = useRef(false);
+  const hasShownGeolocationErrorRef = useRef(false);
+
+  useEffect(() => {
+    if (!mapInstance) {
       return;
     }
 
-    navigator.geolocation.getCurrentPosition(
+    const showGeolocationAlertOnce = (message: string) => {
+      if (hasShownGeolocationErrorRef.current) {
+        return;
+      }
+
+      hasShownGeolocationErrorRef.current = true;
+      window.alert(message);
+    };
+
+    if (!navigator.geolocation) {
+      showGeolocationAlertOnce("Geolocation is not supported by your browser.");
+      return;
+    }
+
+    const watchId = navigator.geolocation.watchPosition(
       (position) => {
         const newLocation: LatLng = {
           lat: position.coords.latitude,
           lng: position.coords.longitude,
         };
+        const now = Date.now();
+        const lastAcceptedLocation = lastAcceptedLocationRef.current;
+        const lastAcceptedTimestamp = lastAcceptedTimestampRef.current;
 
+        if (lastAcceptedLocation && lastAcceptedTimestamp !== null) {
+          const elapsedSinceLastAccepted = now - lastAcceptedTimestamp;
+          if (elapsedSinceLastAccepted < LOCATION_UPDATE_MIN_INTERVAL_MS) {
+            return;
+          }
+
+          const distanceFromLastAccepted = haversineDistanceMeters(lastAcceptedLocation, newLocation);
+          if (distanceFromLastAccepted < LOCATION_UPDATE_MIN_DISTANCE_METERS) {
+            return;
+          }
+        }
+
+        lastAcceptedLocationRef.current = newLocation;
+        lastAcceptedTimestampRef.current = now;
         onUserLocationChange(newLocation);
 
-        if (mapInstance) {
+        if (!hasCenteredOnUserRef.current) {
+          hasCenteredOnUserRef.current = true;
           mapInstance.flyTo([newLocation.lat, newLocation.lng], MAP_MAX_ZOOM, { duration: 1.2 });
         }
       },
       (error) => {
         console.error("Geolocation error", error);
-        window.alert("Unable to retrieve your location. Please allow location access and try again.");
+        showGeolocationAlertOnce(
+          "Unable to retrieve your location. Please allow location access and try again."
+        );
       },
-      {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 0,
-      }
+      GEOLOCATION_OPTIONS
     );
-  };
 
-  const [hasAttemptedGeolocation, setHasAttemptedGeolocation] = useState(false);
+    geolocationWatchIdRef.current = watchId;
 
-  useEffect(() => {
-    if (mapInstance && !userLocation && !hasAttemptedGeolocation) {
-      setHasAttemptedGeolocation(true);
-      locateUser();
-    }
-  }, [mapInstance, userLocation, hasAttemptedGeolocation]);
+    return () => {
+      navigator.geolocation.clearWatch(watchId);
 
-  useEffect(() => {
-    if (userLocation && mapInstance) {
-      mapInstance.flyTo([userLocation.lat, userLocation.lng], MAP_MAX_ZOOM, { duration: 0.9 });
-    }
-  }, [userLocation, mapInstance]);
+      if (geolocationWatchIdRef.current === watchId) {
+        geolocationWatchIdRef.current = null;
+      }
+    };
+  }, [mapInstance, onUserLocationChange]);
 
   return (
     <div className="h-full min-h-[100svh] w-full">


### PR DESCRIPTION
## Title
Real-time user tracking with distance/time gating

## Summary
Switch map geolocation from one-time lookup to continuous tracking so the marker follows user movement, while preventing noisy/frequent updates.

## Changes
- Replace `getCurrentPosition` with `watchPosition`
- Accept first fix immediately
- After first fix, only update when:
  - movement is `>= 8m`
  - and at least `5s` has passed since the last accepted update
- Auto-center map only on the first accepted fix (no repeated camera jumps)
- Use balanced geolocation options:
  - `enableHighAccuracy: false`
  - `timeout: 10000`
  - `maximumAge: 5000`
- Clear geolocation watch on unmount