### PR TITLE
Enhance map functionality with bounds checking

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -107,6 +107,6 @@ a:focus-visible {
 
 @media (max-width: 768px) {
   .leaflet-container .leaflet-bottom .leaflet-control {
-    margin-bottom: calc(max(1rem, env(safe-area-inset-bottom)) + .5rem) !important;
+    margin-bottom: calc(max(1rem, env(safe-area-inset-bottom)) + 4rem) !important;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default async function HomePage() {
   const buildings = await getBuildings();
 
   return (
-    <main className="relative h-screen min-h-[100svh] w-screen overflow-hidden bg-background">
+    <main className="relative h-[100dvh] min-h-[100dvh] w-screen overflow-hidden bg-background">
       <div className="pointer-events-none absolute inset-0 z-[1]">
         <div className="absolute top-[-6rem] left-[-6rem] h-72 w-72 rounded-full bg-[var(--brand-400)]/20 blur-3xl" />
         <div className="absolute top-[-8rem] right-[-4rem] h-80 w-80 rounded-full bg-[var(--accent-500)]/10 blur-3xl" />

--- a/components/ui/Map.test.tsx
+++ b/components/ui/Map.test.tsx
@@ -7,6 +7,7 @@ import type { Building } from "@/lib/types";
 const flyToMock = vi.fn();
 const watchPositionMock = vi.fn();
 const clearWatchMock = vi.fn();
+const alertMock = vi.fn();
 const GEOLOCATION_WATCH_ID = 91;
 const mockedLeafletMap = {
   flyTo: flyToMock,
@@ -139,12 +140,18 @@ describe("Map marker nearest-state rendering", () => {
         clearWatch: clearWatchMock,
       },
     });
+
+    Object.defineProperty(window, "alert", {
+      writable: true,
+      value: alertMock,
+    });
   });
 
   beforeEach(() => {
     flyToMock.mockClear();
     watchPositionMock.mockReset();
     clearWatchMock.mockReset();
+    alertMock.mockReset();
     geolocationSuccessHandler = null;
 
     watchPositionMock.mockImplementation((success: PositionCallback) => {
@@ -246,7 +253,7 @@ describe("Map marker nearest-state rendering", () => {
 
     expect(onUserLocationChange).toHaveBeenCalledTimes(1);
     expect(flyToMock.mock.calls.length).toBe(flyToCountBeforeFirstFix + 1);
-    expect(flyToMock).toHaveBeenLastCalledWith([5.3561, 100.2991], 19, { duration: 1.2 });
+    expect(flyToMock).toHaveBeenLastCalledWith([5.3561, 100.2991], 20, { duration: 1.2 });
 
     nowSpy.mockRestore();
   });
@@ -354,5 +361,54 @@ describe("Map marker nearest-state rendering", () => {
     expect(flyToMock.mock.calls.length).toBe(flyToCountAfterFirstFix);
 
     nowSpy.mockRestore();
+  });
+
+  it("does not auto-focus or update user location when position is outside USM bounds", () => {
+    const onUserLocationChange = vi.fn();
+
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={onUserLocationChange}
+      />
+    );
+
+    const flyToCountBeforeOutsideFix = flyToMock.mock.calls.length;
+
+    emitGeolocationSuccess(5.4, 100.35);
+
+    expect(onUserLocationChange).not.toHaveBeenCalled();
+    expect(flyToMock.mock.calls.length).toBe(flyToCountBeforeOutsideFix);
+    expect(alertMock).toHaveBeenCalledWith("You are outside USM campus map bounds.");
+  });
+
+  it("shows outside-bounds popup once per outside episode", () => {
+    const onUserLocationChange = vi.fn();
+
+    render(
+      <Map
+        buildings={BUILDINGS}
+        onBuildingSelect={vi.fn()}
+        selectedBuildingId={null}
+        nearestBuildingId={null}
+        userLocation={null}
+        onUserLocationChange={onUserLocationChange}
+      />
+    );
+
+    emitGeolocationSuccess(5.4, 100.35);
+    emitGeolocationSuccess(5.42, 100.36);
+
+    expect(alertMock).toHaveBeenCalledTimes(1);
+
+    emitGeolocationSuccess(5.3561, 100.2991);
+    emitGeolocationSuccess(5.4, 100.35);
+
+    expect(alertMock).toHaveBeenCalledTimes(2);
+    expect(onUserLocationChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/components/ui/Map.tsx
+++ b/components/ui/Map.tsx
@@ -17,7 +17,7 @@ interface MapProps {
 }
 
 const USM_CENTER: [number, number] = [5.356174000404129, 100.2989353671396];
-const USM_BOUNDS: LatLngBoundsExpression = [
+const USM_BOUNDS: [[number, number], [number, number]] = [
   [5.351636862846997, 100.2865113240709],
   [5.363583489536974, 100.31088833599742],
 ];
@@ -32,6 +32,16 @@ const GEOLOCATION_OPTIONS: PositionOptions = {
   timeout: 10000,
   maximumAge: 5000,
 };
+
+function isWithinUsmBounds(location: LatLng): boolean {
+  const [[southWestLat, southWestLng], [northEastLat, northEastLng]] = USM_BOUNDS;
+  return (
+    location.lat >= southWestLat &&
+    location.lat <= northEastLat &&
+    location.lng >= southWestLng &&
+    location.lng <= northEastLng
+  );
+}
 
 function MapController({
   buildings,
@@ -147,6 +157,7 @@ export default function Map({
   const lastAcceptedTimestampRef = useRef<number | null>(null);
   const hasCenteredOnUserRef = useRef(false);
   const hasShownGeolocationErrorRef = useRef(false);
+  const hasShownOutsideBoundsAlertRef = useRef(false);
 
   useEffect(() => {
     if (!mapInstance) {
@@ -173,6 +184,17 @@ export default function Map({
           lat: position.coords.latitude,
           lng: position.coords.longitude,
         };
+
+        if (!isWithinUsmBounds(newLocation)) {
+          if (!hasShownOutsideBoundsAlertRef.current) {
+            hasShownOutsideBoundsAlertRef.current = true;
+            window.alert("You are outside USM campus map bounds.");
+          }
+          return;
+        }
+
+        hasShownOutsideBoundsAlertRef.current = false;
+
         const now = Date.now();
         const lastAcceptedLocation = lastAcceptedLocationRef.current;
         const lastAcceptedTimestamp = lastAcceptedTimestampRef.current;
@@ -219,7 +241,7 @@ export default function Map({
   }, [mapInstance, onUserLocationChange]);
 
   return (
-    <div className="h-full min-h-[100svh] w-full">
+    <div className="h-full min-h-[100dvh] w-full">
       <MapContainer
         center={USM_CENTER}
         zoom={MAP_MIN_ZOOM}


### PR DESCRIPTION
Prevent the map from trying to follow users when their geolocation is outside the USM map bounds, and show a clear popup notification instead

Should fix both #13 and #15 